### PR TITLE
Add pipeline operator tests

### DIFF
--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "bun:test"
+import { Lexer } from "../src/lexer"
+import { Parser } from "../src/parser"
+import { generateTypeScript } from "../src/codegen"
+
+describe("Pipeline Operator", () => {
+  it("should parse pipeline operator expressions", () => {
+    const source = "x | double"
+    const lexer = new Lexer(source)
+    const tokens = lexer.tokenize()
+
+    expect(tokens[0].type).toBe("IDENTIFIER")
+    expect(tokens[0].value).toBe("x")
+    expect(tokens[1].type).toBe("PIPE")
+    expect(tokens[1].value).toBe("|")
+    expect(tokens[2].type).toBe("IDENTIFIER")
+    expect(tokens[2].value).toBe("double")
+  })
+
+  it("should generate TypeScript code for pipeline operations", () => {
+    const source = "let result = x | double"
+    const parser = new Parser(source)
+    const program = parser.parse()
+    const tsCode = generateTypeScript(program.statements)
+
+    expect(tsCode).toContain("pipe(")
+    expect(tsCode).toContain("x")
+    expect(tsCode).toContain("double")
+  })
+
+  it("should handle chained pipeline operations", () => {
+    const source = "x | double | add"
+    const lexer = new Lexer(source)
+    const tokens = lexer.tokenize()
+
+    // x | double | add should tokenize correctly
+    expect(tokens[0].type).toBe("IDENTIFIER")
+    expect(tokens[1].type).toBe("PIPE") 
+    expect(tokens[2].type).toBe("IDENTIFIER")
+    expect(tokens[3].type).toBe("PIPE")
+    expect(tokens[4].type).toBe("IDENTIFIER")
+  })
+})


### PR DESCRIPTION
## Summary
- Add comprehensive tests for pipeline operator functionality
- Test basic pipeline operator parsing (x | double)
- Test TypeScript code generation for pipeline operations
- Test chained pipeline operations (x | double | add)

## Test Results
✅ All pipeline tests pass (3/3)
✅ 14 expect() calls successful

## Changes
- New test file: `tests/pipeline.test.ts`
- Tests cover lexing, parsing, and code generation
- Validates pipeline operator behavior

🤖 Generated with [Claude Code](https://claude.ai/code)