### PR TITLE
feat: TypeScript transpiler with CLI command

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,10 @@
       "mcp__github-mcp-server__create_pull_request_review",
       "mcp__github-mcp-server__merge_pull_request",
       "Bash(git pull:*)",
-      "Bash(ln:*)"
+      "Bash(ln:*)",
+      "Bash(bun link:*)",
+      "Bash(seseragi compile:*)",
+      "Bash(seseragi:*)"
     ],
     "deny": []
   }

--- a/examples/simple.ssrg
+++ b/examples/simple.ssrg
@@ -1,0 +1,6 @@
+// Simple Seseragi example
+fn add a :Int -> b :Int -> Int = a + b
+
+let greeting :String = "Hello"
+
+fn double x :Int -> Int = x * 2

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,0 +1,38 @@
+// Generated TypeScript code from Seseragi
+
+// Seseragi runtime helpers
+
+// カリー化関数のヘルパー
+const curry = (fn: Function) => {
+  return function curried(...args: any[]) {
+    if (args.length >= fn.length) {
+      return fn.apply(this, args);
+    } else {
+      return function(...args2: any[]) {
+        return curried.apply(this, args.concat(args2));
+      };
+    }
+  };
+};
+
+// パイプライン演算子のヘルパー
+const pipe = <T, U>(value: T, fn: (arg: T) => U): U => fn(value);
+
+// 逆パイプ演算子のヘルパー
+const reversePipe = <T, U>(fn: (arg: T) => U, value: T): U => fn(value);
+
+// モナドバインドのヘルパー（Maybe用）
+const bind = <T, U>(maybe: T | null | undefined, fn: (value: T) => U | null | undefined): U | null | undefined => {
+  return maybe != null ? fn(maybe) : null;
+};
+
+// 畳み込みモノイドのヘルパー
+const foldMonoid = <T>(arr: T[], empty: T, combine: (a: T, b: T) => T): T => {
+  return arr.reduce(combine, empty);
+};
+
+const add = curry((a: number, b: number): number => (a + b));
+
+const greeting: string = "Hello";
+
+const double = (x: number): number => (x * 2);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "seseragi",
   "version": "1.0.0",
   "main": "src/main.ts",
+  "bin": {
+    "seseragi": "./src/cli.ts"
+  },
   "scripts": {
     "dev": "bun run --watch src/main.ts",
     "build": "bun build src/main.ts --outdir dist --target node",
@@ -16,7 +19,8 @@
     "format:check": "biome format src tests",
     "clean": "rm -rf dist",
     "seseragi": "bun run src/cli.ts",
-    "seseragi:format": "bun run src/cli.ts format"
+    "seseragi:format": "bun run src/cli.ts format",
+    "seseragi:compile": "bun run src/cli.ts compile"
   },
   "keywords": [],
   "author": "",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 import { Command } from 'commander';
 import { formatCommand } from './cli/format.js';
+import { compileCommand } from './cli/compile.js';
 
 const program = new Command();
 
@@ -26,6 +27,24 @@ program
       check: options.check,
       removeWhitespace: options.removeWhitespace,
       normalizeSpacing: options.normalizeSpacing,
+    });
+  });
+
+program
+  .command('compile')
+  .description('Compile Seseragi source to TypeScript')
+  .argument('<file>', 'Seseragi source file to compile')
+  .option('-o, --output <file>', 'Output TypeScript file')
+  .option('-w, --watch', 'Watch for file changes and recompile')
+  .option('--no-comments', 'Do not generate comments in output')
+  .option('--function-declarations', 'Use function declarations instead of arrow functions')
+  .action(async (file, options) => {
+    await compileCommand({
+      input: file,
+      output: options.output,
+      watch: options.watch,
+      generateComments: !options.noComments,
+      useArrowFunctions: !options.functionDeclarations,
     });
   });
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -72,6 +72,7 @@ export enum TokenType {
   NEWLINE = "NEWLINE",
   EOF = "EOF",
   WHITESPACE = "WHITESPACE",
+  COMMENT = "COMMENT",
 }
 
 export interface Token {
@@ -204,6 +205,9 @@ export class Lexer {
       case "*":
         return this.makeToken(TokenType.MULTIPLY, char, startLine, startColumn)
       case "/":
+        if (this.peek() === "/") {
+          return this.comment(startLine, startColumn)
+        }
         return this.makeToken(TokenType.DIVIDE, char, startLine, startColumn)
       case "%":
         return this.makeToken(TokenType.MODULO, char, startLine, startColumn)
@@ -448,5 +452,19 @@ export class Lexer {
 
   private isAlphaNumeric(char: string): boolean {
     return this.isAlpha(char) || this.isDigit(char)
+  }
+
+  private comment(startLine: number, startColumn: number): Token {
+    // Skip the first /
+    this.advance()
+
+    let value = ""
+
+    // Read until end of line or end of file
+    while (this.peek() !== "\n" && !this.isAtEnd()) {
+      value += this.advance()
+    }
+
+    return this.makeToken(TokenType.COMMENT, value, startLine, startColumn)
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,7 +27,7 @@ export class Parser {
     const statements: AST.Statement[] = []
 
     while (!this.isAtEnd()) {
-      if (this.peek().type === TokenType.NEWLINE) {
+      if (this.peek().type === TokenType.NEWLINE || this.peek().type === TokenType.COMMENT) {
         this.advance()
         continue
       }
@@ -76,10 +76,11 @@ export class Parser {
         return this.returnStatement()
       }
 
-      // Skip whitespace and newlines
+      // Skip whitespace, newlines, and comments
       if (
         this.peek().type === TokenType.NEWLINE ||
-        this.peek().type === TokenType.WHITESPACE
+        this.peek().type === TokenType.WHITESPACE ||
+        this.peek().type === TokenType.COMMENT
       ) {
         this.advance()
         return null

--- a/tests/compile.test.ts
+++ b/tests/compile.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { compileCommand } from '../src/cli/compile';
+
+const testDir = path.join(__dirname, 'tmp');
+const testInputFile = path.join(testDir, 'test.ssrg');
+const testOutputFile = path.join(testDir, 'test.ts');
+
+describe('Compile Command', () => {
+  beforeEach(() => {
+    // テスト用ディレクトリの作成
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    // テスト用ファイルのクリーンアップ
+    [testInputFile, testOutputFile].forEach((file) => {
+      if (fs.existsSync(file)) {
+        fs.unlinkSync(file);
+      }
+    });
+  });
+
+  it('should compile simple function to TypeScript', async () => {
+    // テスト用のSeseragiソースコード
+    const seseragiCode = `fn add a :Int -> b :Int -> Int = a + b`;
+    
+    fs.writeFileSync(testInputFile, seseragiCode);
+
+    await compileCommand({
+      input: testInputFile,
+      output: testOutputFile,
+      generateComments: false,
+      useArrowFunctions: true,
+    });
+
+    expect(fs.existsSync(testOutputFile)).toBe(true);
+    
+    const compiledCode = fs.readFileSync(testOutputFile, 'utf-8');
+    expect(compiledCode).toContain('add');
+    expect(compiledCode).toContain('=>');
+  });
+
+  it('should compile variable declaration to TypeScript', async () => {
+    const seseragiCode = `let greeting :String = "Hello, Seseragi!"`;
+    
+    fs.writeFileSync(testInputFile, seseragiCode);
+
+    await compileCommand({
+      input: testInputFile,
+      output: testOutputFile,
+      generateComments: false,
+      useArrowFunctions: true,
+    });
+
+    expect(fs.existsSync(testOutputFile)).toBe(true);
+    
+    const compiledCode = fs.readFileSync(testOutputFile, 'utf-8');
+    expect(compiledCode).toContain('greeting');
+    expect(compiledCode).toContain('Hello, Seseragi!');
+  });
+
+  it('should use default output filename when not specified', async () => {
+    const seseragiCode = `fn double x :Int -> Int = x * 2`;
+    
+    fs.writeFileSync(testInputFile, seseragiCode);
+
+    await compileCommand({
+      input: testInputFile,
+      generateComments: false,
+      useArrowFunctions: true,
+    });
+
+    const defaultOutputFile = path.join(testDir, 'test.ts');
+    expect(fs.existsSync(defaultOutputFile)).toBe(true);
+    
+    const compiledCode = fs.readFileSync(defaultOutputFile, 'utf-8');
+    expect(compiledCode).toContain('double');
+  });
+
+  it('should throw error for non-existent input file', async () => {
+    const nonExistentFile = path.join(testDir, 'nonexistent.ssrg');
+    
+    await expect(compileCommand({
+      input: nonExistentFile,
+      output: testOutputFile,
+    })).rejects.toThrow('Input file not found');
+  });
+
+  it('should compile with function declarations when useArrowFunctions is false', async () => {
+    const seseragiCode = `fn multiply x :Int -> y :Int -> Int = x * y`;
+    
+    fs.writeFileSync(testInputFile, seseragiCode);
+
+    await compileCommand({
+      input: testInputFile,
+      output: testOutputFile,
+      generateComments: false,
+      useArrowFunctions: false,
+    });
+
+    expect(fs.existsSync(testOutputFile)).toBe(true);
+    
+    const compiledCode = fs.readFileSync(testOutputFile, 'utf-8');
+    expect(compiledCode).toContain('function');
+  });
+});


### PR DESCRIPTION
## Summary
- TypeScriptトランスパイラーの実装
- CLIコマンド `seseragi compile` の追加
- グローバルコマンドとしての実行サポート
- ファイル監視機能付きの自動再コンパイル

## Features
- **コンパイルコマンド**: `seseragi compile <file>` で標準出力またはファイル出力
- **監視モード**: `--watch` オプションでファイル変更の自動検知
- **柔軟な出力**: stdout出力とファイル出力の両方をサポート  
- **コメント対応**: `//` 形式のコメントをサポート
- **グローバル実行**: `bun link` でグローバルコマンド化

## Generated TypeScript
- カリー化関数の自動変換
- パイプライン演算子のヘルパー関数
- モナド操作のサポート関数
- 適切な型アノテーション

## Test plan
- [x] 基本的な関数定義のコンパイル
- [x] 変数定義のコンパイル
- [x] 標準出力への出力
- [x] ファイルへの出力
- [x] エラーハンドリング（存在しないファイル）
- [x] アロー関数と関数宣言の切り替え
- [x] グローバルコマンドとしての実行

🤖 Generated with [Claude Code](https://claude.ai/code)