### PR TITLE
fix: Add TuplePattern and WildcardPattern support to match expressions

### DIFF
--- a/examples/fizzbuzz.ssrg
+++ b/examples/fizzbuzz.ssrg
@@ -1,9 +1,9 @@
-fn fizzbuzz f :Int -> b :Int -> x :Int -> String =
-  x % (f * b) == 0 ? "FizzBuzz" :
-  x % f == 0 ? "Fizz" :
-  x % b == 0 ? "Buzz" :
-  toString x
+fn fizzbuzz x :Int -> String = match (x % 3, x % 5) {
+  (0, 0) -> "FizzBuzz"
+  (0, _) -> "Fizz"
+  (_, 0) -> "Buzz"
+  _ -> toString x
+}
 
-let fb = fizzbuzz 3 5
-show $ `[fb x | x <- 1..=100]
+show $ `[fizzbuzz x | x <- 1..=100]
 

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1682,6 +1682,17 @@ ${indent}}`
         // ADTコンストラクタパターン
         return `${valueVar}.type === '${pattern.constructorName}'`
       
+      case "TuplePattern":
+        // タプルパターン
+        const tupleConditions = pattern.patterns.map((subPattern, i) => {
+          return this.generatePatternCondition(subPattern, `${valueVar}[${i}]`)
+        })
+        return tupleConditions.join(" && ")
+      
+      case "WildcardPattern":
+        // ワイルドカードパターン
+        return "true"
+      
       default:
         // 後方互換性のための古い形式をチェック
         if (pattern.value !== undefined) {


### PR DESCRIPTION
## Summary
- `match`式でタプルパターンマッチングが正しく動作するよう修正
- `generatePatternCondition`メソッドに欠けていた`TuplePattern`と`WildcardPattern`のケースを追加
- `examples/fizzbuzz.ssrg`が正常に動作することを確認

## Problem
`match`式でタプルパターン（例：`(0, 0)`）を使用すると、コード生成時に不正なJavaScriptコードが生成され、実行時エラーが発生していました。

## Solution
`src/codegen.ts`の`generatePatternCondition`メソッドに以下を追加：
- **TuplePattern**: 各要素を再帰的にパターンマッチング
- **WildcardPattern**: 常に`true`を返す
