### PR TITLE
docs: redesign root README as Seseragi entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,125 +6,174 @@
   </picture>
 </p>
 
+<p align="center"><strong>型・Effect・Signal・DOMを、ひとつの言語として組み立てる。</strong></p>
+
+<p align="center">
+  <a href="https://seseragi.vercel.app/">Playground</a>
+  · <a href="https://seseragi.vercel.app/tour/">Tour</a>
+  · <a href="./docs/README.md">Language specification</a>
+  · <a href="./extensions/seseragi/README.md">VS Code</a>
+</p>
+
+> [!IMPORTANT]
+> Seseragiは現在 **experimental / pre-release** です。Rust compiler、CLI、LSP、WASM
+> Playground、Signal / DOM runtimeを同じdriverから育てている段階で、production利用を
+> 前提とした互換性はまだ保証していません。
+
 # Seseragi
 
-Seseragiは、独自の型・Effect semanticsを持ち、TypeScript / JavaScriptを
-実行targetの一つとして生成するプログラミング言語です。言語の意味と構文の正本は
-[Seseragi言語仕様](./docs/README.md)です。
+Seseragiは、独自の型とEffect semanticsを持つプログラミング言語です。
+TypeScript / JavaScriptは実行targetの一つであり、言語の意味と構文は
+[Seseragi言語仕様](./docs/README.md)を正本とします。
 
-現在のcompilerはRust実装です。旧TypeScript compilerは移行完了に伴って削除し、
-parser、型検査、lowering、CLI、LSP、WASMはすべて `crates/` の同じdriver境界を
-共有します。
+現行compilerはRust実装です。parser、型検査、lowering、CLI、LSP、WASM Playgroundが
+同じdriver境界を共有するため、editorで見える型と実行時にcompileされるprogramを
+別実装へ分岐させません。
+
+## まず試す
+
+- **[Playground](https://seseragi.vercel.app/)** — browser上で編集・型検査・実行・HTML Preview
+- **[A Tour of Seseragi](https://seseragi.vercel.app/tour/)** — Hello worldからEffect、Signal、Web UIまで順に試す
+- **[Runnable samples](./examples/samples/README.md)** — 現行compilerで実行されるsample catalog
+- **[VS Code extension](./extensions/seseragi/README.md)** — syntax highlight、hover、completion、diagnostic、formatter
+
+## 言語の形
+
+次の例は、現行compilerとPlaygroundのsample checkで実行される
+[`examples/samples/data-and-patterns/main.ssrg`](./examples/samples/data-and-patterns/main.ssrg)
+をそのまま掲載しています。
+
+<!-- canonical-example: path=examples/samples/data-and-patterns/main.ssrg -->
+```seseragi
+type Delivery =
+  | Preparing
+  | Shipped String
+
+fn message delivery: Delivery -> String =
+  match delivery {
+    Preparing -> "Preparing your order"
+    Shipped city -> `Shipped to ${city}`
+  }
+
+// constructorをすべて扱うので、このmatchは網羅的です。
+pub effect fn main =
+  Shipped "Osaka"
+  |> message
+  |> println
+```
+<!-- /canonical-example -->
+
+```text
+Shipped to Osaka
+```
+
+この短いprogramだけでも、取り得る状態を`type`で閉じ、`match`で漏れなく扱い、
+pureな変換を`|>`でつなぎ、最後の出力だけをEffectとして実行できます。
+
+## Seseragiで扱うsurface
+
+| Surface | 現在書けるもの |
+| --- | --- |
+| Data / types | ADT、Struct、Record、generic、pattern match、newtype、type alias |
+| Composition | function、pipeline、custom operator、Functor / Applicative / Monad instance |
+| Effects | `effect fn`、`do`、typed failure、Console / Stdin、resource境界の一部 |
+| Reactive UI | `Signal`、pure HTML、function component、browser DOM event、form、IME composition |
+| Tooling | Rust CLI、formatter、native LSP、VS Code extension、WASM Playground |
+
+実装済み範囲と未接続領域は[STATUS](./docs/STATUS.md)に明記しています。
+仕様に存在することと、現行compilerで動くことは同一ではありません。
 
 ## Quick start
 
-必要なtoolchainはRust、Bun、PlaygroundのWASMを再生成する場合は
-`wasm-pack`です。
+必要なtoolchainはRustとBunです。PlaygroundのWASMを再生成する場合だけ`wasm-pack`も使います。
 
 ```sh
-# Rust CLIをbuild
+# compilerをbuild
 cargo build -p seseragi-cli
 
-# single-file programをcompileして実行
+# canonical Hello worldをcompileして実行
 cargo run -p seseragi-cli -- run examples/samples/hello-world/main.ssrg
 
-# 実行せず、再現可能なTypeScript成果物をdist/へ出力
+# TypeScript成果物をdist/へ生成して実行
 cargo run -p seseragi-cli -- build examples/samples/hello-world/main.ssrg
 bun run dist/entry.ts
-
-# local packageのmodule graph全体を同じ成果物へ出力
-cargo run -p seseragi-cli -- build \
-  examples/spec/fixtures/projects/cli-build-nested
 
 # formatter
 cargo run -p seseragi-cli -- format --check \
   examples/spec/artifacts/schema-1/rock-paper-scissors-cli/main.ssrg
 ```
 
-`run`はsingle fileだけでなく、`seseragi.json`を持つlocal packageも受け取れます。
-生成TypeScriptの実行にはBunを使います。
-
-`build`はsingle fileを既定の`dist/`、または`--out-dir`で指定したdirectoryへ
-永続出力します。成果物には`main.ts`、`main.ts.map`、
-`generated-module.json`、Bun用`entry.ts`、versioned TypeScript runtimeが
-含まれます。同じ入力の再buildではdirectory全体を再生成しますが、
-`.seseragi-build.json`を持たない既存の非空directoryは誤削除を避けるため
-上書きしません。
-
-local packageを渡した場合は、`run`と同じmanifest・module graph・entry解決を
-使い、compilerが計画した`dist/packages/<name>/<version>/...`構成を保って
-全moduleのTypeScript、source map、metadataを出力します。`entry.ts`から
-実行するため、成果物directory内で`bun run entry.ts`を使えます。
-
-## Release identity
-
-CLIとLSPは同じtoolchain version、commit、build channelを公開します。
-
-```sh
-cargo run -p seseragi-cli -- --version
-cargo run -p seseragi-lsp -- --version-json
-bun run release:info
-```
-
-versionの正本、tag、artifact名、bump手順は[Release contract](./docs/RELEASE.md)を参照してください。
+`run`と`build`はsingle fileに加えて、`seseragi.json`を持つlocal packageも受け取ります。
+生成物の構成、project discovery、release identityは
+[implementation documentation](./docs/IMPLEMENTATION.md)と
+[release contract](./docs/RELEASE.md)を参照してください。
 
 ## Playground
 
 ```sh
-# compiler / runtime contract変更時にWASMを再生成
-bun run build:playground:wasm
-
 # local development
 bun run dev:playground
+
+# sample、Tour、test、typecheck、bundleを検証
+bun run check:playground
+
+# compiler / runtime contract変更時にWASMを再生成
+bun run build:playground:wasm
 ```
 
-production相当のtest、typecheck、bundleは `bun run check:playground` で確認できます。
-公開版は <https://seseragi.vercel.app/> です。
+PlaygroundのLearn / Discover catalogは`examples/tour/`と`examples/samples/`を正本に生成します。
+READMEやUIへだけ動かないsampleを複製しません。
 
-実装済みsurfaceだけで動く学習・発見用サンプルは `examples/samples/<slug>/` が正本です。
-directoryへmetadata、source、guide、期待出力を追加するとmanifestへ自動検出されます。
-`bun run test:samples:cli` は同じsourceをnative CLIでも検証します。
+## VS Code
 
-## Repository boundary
+正式extension IDは`seseragi-dev.seseragi`です。GitHub ReleaseからOS / CPUに合うVSIXを取得し、
+`Extensions: Install from VSIX...`で導入します。VSIXには対応するnative `seseragi-lsp`が
+一つだけ同梱されます。
+
+導入方法、formatter設定、旧preview IDからのmigrationは
+[Seseragi for VS Code](./extensions/seseragi/README.md)を参照してください。
+
+## Project status
+
+- compiler / runtimeはRust再実装の縦sliceを継続中
+- CLI、LSP、formatter、WASM Playgroundは同じcompiler driverへ接続済み
+- ADT、match、Effect、Signal、SSR / DOMの実行可能範囲をsampleとconformance fixtureで固定
+- TypeScript interop、filesystem / HTTP、Stream、hydration等は未着手または部分実装
+- release前のため、構文・型・runtime contractは変更される可能性あり
+
+正確な現在地は[STATUS](./docs/STATUS.md)、実装順は[ROADMAP](./docs/ROADMAP.md)、
+仕様の検証範囲は[SPEC COVERAGE](./docs/SPEC_COVERAGE.md)を参照してください。
+
+## Repository guide
 
 | Path | Role |
-|---|---|
-| `crates/` | 現行Rust compiler、driver、CLI、LSP、WASM、conformance |
-| `runtime/ts/` | 生成コードが使う現行TypeScript runtimeとbrowser host |
-| `apps/playground/` | 現行CodeMirror / WASM Playground |
-| `examples/samples/` | 現行compilerで実行するsample catalog |
-| `examples/spec/` | canonical lesson、fixture、execution artifact |
+| --- | --- |
+| `crates/` | Rust compiler、driver、CLI、LSP、WASM、conformance |
+| `runtime/ts/` | 生成codeが接続するversioned TypeScript runtime |
+| `apps/playground/` | CodeMirror / WASM PlaygroundとTour |
+| `examples/samples/` | 現行compilerで動くsample catalog |
+| `examples/tour/` | Playground Tourのcanonical lesson |
+| `examples/spec/` | specification lesson、fixture、execution artifact |
 | `docs/spec/` | normative language specification |
-| `extensions/seseragi/` | TextMate grammarと同梱native LSPを提供する正式なVS Code extension（ID: `seseragi-dev.seseragi`） |
-
-`runtime/ts`と`apps/playground`のTypeScriptは旧compilerではありません。前者は
-Rust backendが生成コードへ接続するruntime、後者は同じRust driverをWASM経由で
-呼ぶUIです。compiler実装をroot `src/`へ追加しないでください。
+| `extensions/seseragi/` | 正式なVS Code extension |
 
 ## Development
 
+変更範囲に応じてscoped gateを選びます。
+
 ```sh
-# 変更範囲に応じた短い検証
+bun run check:sample
 bun run check:playground
 bun run check:rust
 bun run check:extension
+bun run check:release
 
-# CI-equivalent repository-wide gate（統合時のみ）
+# 複数領域を横断する統合時のみ
 bun run check
-
-# Rustとactive TypeScript sourcesをformat
-bun run format
-
-# native workspaceとPlayground bundleをbuild
-bun run build
 ```
 
-詳しい現在地と実装方針は
-[STATUS](./docs/STATUS.md)、[ROADMAP](./docs/ROADMAP.md)、
-[IMPLEMENTATION](./docs/IMPLEMENTATION.md)を参照してください。
-
-検証laneの選び方とfull gateの実行条件は
-[Scoped checks](./docs/SCOPED_CHECKS.md)を参照してください。
+検証laneの選択基準は[Scoped checks](./docs/SCOPED_CHECKS.md)、contributionの前提は
+[CONTRIBUTING](./CONTRIBUTING.md)を参照してください。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ bun run check:release
 bun run check
 ```
 
-検証laneの選択基準は[Scoped checks](./docs/SCOPED_CHECKS.md)、contributionの前提は
-[CONTRIBUTING](./CONTRIBUTING.md)を参照してください。
+検証laneの選択基準は[Scoped checks](./docs/SCOPED_CHECKS.md)、compiler / runtimeの責務境界は
+[IMPLEMENTATION](./docs/IMPLEMENTATION.md)を参照してください。
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "./scripts/build.sh",
     "check": "./scripts/check.sh",
     "check:full": "./scripts/check-scoped.sh full",
+    "check:readme": "bun scripts/check-readme.ts",
     "check:sample": "./scripts/check-scoped.sh sample",
     "check:playground": "./scripts/check-scoped.sh playground",
     "check:rust": "./scripts/check-scoped.sh rust",

--- a/scripts/check-readme.ts
+++ b/scripts/check-readme.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const readmePath = resolve(root, "README.md")
+const readme = readFileSync(readmePath, "utf8")
+
+const normalize = (value: string): string => value.replace(/\r\n/gu, "\n").trimEnd()
+
+const examplePattern =
+  /<!-- canonical-example: path=([^\s]+) -->\r?\n```seseragi\r?\n([\s\S]*?)\r?\n```\r?\n<!-- \/canonical-example -->/u
+const exampleMatch = readme.match(examplePattern)
+
+if (!exampleMatch) {
+  throw new Error("README canonical example marker is missing or malformed")
+}
+
+const sourceRelativePath = exampleMatch[1]
+const sourcePath = resolve(root, sourceRelativePath)
+
+if (!existsSync(sourcePath)) {
+  throw new Error(`README canonical example source does not exist: ${sourceRelativePath}`)
+}
+
+const embeddedSource = normalize(exampleMatch[2])
+const canonicalSource = normalize(readFileSync(sourcePath, "utf8"))
+
+if (embeddedSource !== canonicalSource) {
+  throw new Error(
+    `README canonical example is stale: update it from ${sourceRelativePath}`,
+  )
+}
+
+const localTargets = new Set<string>()
+const markdownLinkPattern = /\]\((\.\.?\/[^)\s]+)(?:\s+"[^"]*")?\)/gu
+const htmlLinkPattern = /\b(?:href|src|srcset)="(\.\.?\/[^"]+)"/gu
+
+for (const pattern of [markdownLinkPattern, htmlLinkPattern]) {
+  for (const match of readme.matchAll(pattern)) {
+    const rawTarget = match[1].split(/[?#]/u, 1)[0]
+    localTargets.add(decodeURIComponent(rawTarget))
+  }
+}
+
+const missingTargets = [...localTargets]
+  .filter((target) => !existsSync(resolve(root, target)))
+  .sort()
+
+if (missingTargets.length > 0) {
+  throw new Error(`README contains missing local targets:\n${missingTargets.join("\n")}`)
+}
+
+console.log(
+  `README check passed: canonical example and ${localTargets.size} local targets are current.`,
+)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,4 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+bun scripts/check-readme.ts
 exec "$ROOT/scripts/check-scoped.sh" full "$@"


### PR DESCRIPTION
Closes #212

## What changed

- keeps the approved theme-aware Seseragi lockup as the hero
- adds a concise tagline, primary Playground / Tour / spec / VS Code actions, and an explicit pre-release status
- promotes a runnable ADT + exhaustive match + pipeline + Effect example from the canonical sample catalog
- reorganizes capabilities, quick start, Playground, VS Code, status, repository guide, and development links for first-time readers
- adds `scripts/check-readme.ts` to reject a stale canonical code block or missing local README links
- exposes `bun run check:readme` and runs the README contract from the full repository gate

## Validation

- canonical snippet matches `examples/samples/data-and-patterns/main.ssrg`
- local README targets are checked by `scripts/check-readme.ts`
- no compiler or runtime code changed
