### PR TITLE
project: unify target selection

### DIFF
--- a/crates/seseragi-cli/src/build.rs
+++ b/crates/seseragi-cli/src/build.rs
@@ -1,13 +1,14 @@
 use std::path::Path;
 
-use crate::local_project::{compile_path, LocalProjectCompilation, LocalProjectTarget};
+use crate::local_project::{compatible_targets, compile_path, LocalProjectCompilation};
 use seseragi_driver::{compile_module, render_terminal_diagnostics, CompileInput};
-use seseragi_runtime::BuildTarget;
+use seseragi_project::{select_project_target, ProjectCommand, ProjectTarget};
+use seseragi_runtime::{main_contract, BuildTarget};
 
 pub(crate) fn build(arguments: &[String]) -> Result<i32, String> {
     let mut path = None;
     let mut output_directory = "dist".to_owned();
-    let mut target = BuildTarget::Process;
+    let mut target = None;
     let mut index = 0;
     while index < arguments.len() {
         match arguments[index].as_str() {
@@ -21,16 +22,12 @@ pub(crate) fn build(arguments: &[String]) -> Result<i32, String> {
             }
             "--target" => {
                 index += 1;
-                target = match arguments.get(index).map(String::as_str) {
-                    Some("process") => BuildTarget::Process,
-                    Some("web") => BuildTarget::Web,
+                target = Some(match arguments.get(index).map(String::as_str) {
                     Some(value) => {
-                        return Err(format!(
-                            "unsupported build target `{value}`; expected `process` or `web`"
-                        ));
+                        ProjectTarget::parse(value).map_err(|error| error.to_string())?
                     }
                     None => return Err("--target requires `process` or `web`".to_owned()),
-                };
+                });
             }
             argument if argument.starts_with('-') => {
                 return Err(format!("unknown build option `{argument}`"));
@@ -47,7 +44,7 @@ pub(crate) fn build(arguments: &[String]) -> Result<i32, String> {
 pub(crate) fn build_path(
     path: &Path,
     output_directory: &Path,
-    target: BuildTarget,
+    target: Option<ProjectTarget>,
 ) -> Result<i32, String> {
     if path.is_dir() {
         build_package(path, output_directory, target)
@@ -56,7 +53,11 @@ pub(crate) fn build_path(
     }
 }
 
-fn build_file(path: &Path, output_directory: &Path, target: BuildTarget) -> Result<i32, String> {
+fn build_file(
+    path: &Path,
+    output_directory: &Path,
+    target: Option<ProjectTarget>,
+) -> Result<i32, String> {
     if path.extension().and_then(|extension| extension.to_str()) != Some("ssrg") {
         return Err("build expects a .ssrg source file".to_owned());
     }
@@ -77,23 +78,44 @@ fn build_file(path: &Path, output_directory: &Path, target: BuildTarget) -> Resu
             render_terminal_diagnostics(&compiled.diagnostics, &source)
         );
     }
-    seseragi_runtime::build_main(&compiled, output_directory, target)
+    let contract =
+        main_contract(&compiled).map_err(|error| format!("invalid entry point: {error}"))?;
+    let compatible = compatible_targets(&contract);
+    let selection = select_project_target(
+        ProjectCommand::Build,
+        target,
+        None,
+        target.is_none().then_some(compatible.as_slice()),
+    )
+    .map_err(|error| error.to_string())?;
+    seseragi_runtime::build_main(&compiled, output_directory, build_target(selection.target))
         .map_err(|error| error.to_string())?;
     println!("Built {} -> {}", path.display(), output_directory.display());
     Ok(0)
 }
 
-fn build_package(path: &Path, output_directory: &Path, target: BuildTarget) -> Result<i32, String> {
-    let compile_target = match target {
-        BuildTarget::Process => LocalProjectTarget::BunProcess,
-        BuildTarget::Web => LocalProjectTarget::Web,
-    };
-    let compiled = match compile_path(path, compile_target)? {
+fn build_package(
+    path: &Path,
+    output_directory: &Path,
+    target: Option<ProjectTarget>,
+) -> Result<i32, String> {
+    let compiled = match compile_path(path, ProjectCommand::Build, target)? {
         LocalProjectCompilation::Compiled(compiled) => compiled,
         LocalProjectCompilation::Diagnostics => return Ok(2),
     };
-    seseragi_runtime::build_local_project(&compiled, output_directory, target)
-        .map_err(|error| error.to_string())?;
+    seseragi_runtime::build_local_project(
+        &compiled.compiled,
+        output_directory,
+        build_target(compiled.target),
+    )
+    .map_err(|error| error.to_string())?;
     println!("Built {} -> {}", path.display(), output_directory.display());
     Ok(0)
+}
+
+fn build_target(target: ProjectTarget) -> BuildTarget {
+    match target {
+        ProjectTarget::Process => BuildTarget::Process,
+        ProjectTarget::Web => BuildTarget::Web,
+    }
 }

--- a/crates/seseragi-cli/src/local_project.rs
+++ b/crates/seseragi-cli/src/local_project.rs
@@ -2,26 +2,54 @@ use seseragi_driver::{
     compile_local_project, compile_local_project_with_providers, render_terminal_diagnostics,
     LinkedCompileError, ProjectCompileError,
 };
+use seseragi_project::{select_project_target, ProjectCommand, ProjectTarget};
+use seseragi_runtime::{project_main_contract, validate_target, ExecutionTarget};
 use std::path::Path;
 
 pub(crate) enum LocalProjectCompilation {
-    Compiled(seseragi_driver::CompiledLocalProject),
+    Compiled(ResolvedLocalProject),
     Diagnostics,
 }
 
-pub(crate) enum LocalProjectTarget {
-    BunProcess,
-    Web,
+pub(crate) struct ResolvedLocalProject {
+    pub compiled: seseragi_driver::CompiledLocalProject,
+    pub target: ProjectTarget,
 }
 
 pub(crate) fn compile_path(
     path: &Path,
-    target: LocalProjectTarget,
+    command: ProjectCommand,
+    invocation_target: Option<ProjectTarget>,
 ) -> Result<LocalProjectCompilation, String> {
     let project = seseragi_project::load_local_project(path)
         .map_err(|error| format!("{}: {error}", error.code()))?;
-    let result = match target {
-        LocalProjectTarget::BunProcess => {
+    let baseline = match render_compile_result(&project, compile_local_project(&project))? {
+        Some(compiled) => compiled,
+        None => return Ok(LocalProjectCompilation::Diagnostics),
+    };
+    let manifest_target = project
+        .packages()
+        .package(project.packages().root())
+        .expect("local project graph contains its root manifest")
+        .manifest()
+        .run
+        .as_ref()
+        .and_then(|run| run.target.as_ref());
+    let contract = project_main_contract(&baseline.compiled, &baseline.entry_module)
+        .map_err(|error| format!("invalid entry point: {error}"))?;
+    let compatible_targets = compatible_targets(&contract);
+    let infer_from_capabilities = command == ProjectCommand::Build
+        && invocation_target.is_none()
+        && manifest_target.is_none();
+    let selection = select_project_target(
+        command,
+        invocation_target,
+        manifest_target,
+        infer_from_capabilities.then_some(compatible_targets.as_slice()),
+    )
+    .map_err(|error| error.to_string())?;
+    let result = match selection.target {
+        ProjectTarget::Process => {
             let resolved = compile_local_project_with_providers(
                 &project,
                 seseragi_runtime::bun_process_provider_configuration()?,
@@ -36,16 +64,46 @@ pub(crate) fn compile_path(
                 {
                     compile_local_project(&project)
                 }
+                Ok(compiled) => Ok(compiled),
                 other => other,
             }
         }
-        LocalProjectTarget::Web => compile_local_project_with_providers(
+        ProjectTarget::Web => compile_local_project_with_providers(
             &project,
             seseragi_runtime::browser_provider_configuration()?,
         ),
     };
+    Ok(match render_compile_result(&project, result)? {
+        Some(compiled) => LocalProjectCompilation::Compiled(ResolvedLocalProject {
+            compiled,
+            target: selection.target,
+        }),
+        None => LocalProjectCompilation::Diagnostics,
+    })
+}
+
+pub(crate) fn compatible_targets(contract: &seseragi_runtime::MainContract) -> Vec<ProjectTarget> {
+    ProjectTarget::ALL
+        .into_iter()
+        .filter(|target| {
+            let target = match target {
+                ProjectTarget::Process => ExecutionTarget::Process,
+                ProjectTarget::Web => ExecutionTarget::Browser,
+            };
+            validate_target(contract, target).is_ok()
+        })
+        .collect()
+}
+
+fn render_compile_result(
+    project: &seseragi_project::LoadedLocalProject,
+    result: Result<
+        seseragi_driver::CompiledLocalProject,
+        seseragi_driver::LocalProjectCompileError,
+    >,
+) -> Result<Option<seseragi_driver::CompiledLocalProject>, String> {
     match result {
-        Ok(compiled) => Ok(LocalProjectCompilation::Compiled(compiled)),
+        Ok(compiled) => Ok(Some(compiled)),
         Err(error) => {
             let diagnostics = match error.error() {
                 ProjectCompileError::Diagnostics { modules } => {
@@ -65,7 +123,7 @@ pub(crate) fn compile_path(
                     "{}",
                     render_terminal_diagnostics(diagnostics, module.source())
                 );
-                return Ok(LocalProjectCompilation::Diagnostics);
+                return Ok(None);
             }
             Err(format!(
                 "project compiler rejected package: {:?}",

--- a/crates/seseragi-cli/src/run/package.rs
+++ b/crates/seseragi-cli/src/run/package.rs
@@ -1,12 +1,13 @@
-use crate::local_project::{compile_path, LocalProjectCompilation, LocalProjectTarget};
+use crate::local_project::{compile_path, LocalProjectCompilation};
+use seseragi_project::ProjectCommand;
 use std::path::Path;
 
 pub(super) fn run_package(path: &Path) -> Result<i32, String> {
-    let compiled = match compile_path(path, LocalProjectTarget::BunProcess)? {
+    let compiled = match compile_path(path, ProjectCommand::Run, None)? {
         LocalProjectCompilation::Compiled(compiled) => compiled,
         LocalProjectCompilation::Diagnostics => return Ok(2),
     };
-    seseragi_runtime::run_local_project(&compiled)
+    seseragi_runtime::run_local_project(&compiled.compiled)
         .map(|outcome| outcome.exit_code)
         .map_err(|error| error.to_string())
 }

--- a/crates/seseragi-cli/tests/build.rs
+++ b/crates/seseragi-cli/tests/build.rs
@@ -61,6 +61,7 @@ fn rejects_unsupported_dom_before_single_file_and_project_builds() {
         let output = Command::new(env!("CARGO_BIN_EXE_seseragi"))
             .arg("build")
             .arg(path)
+            .args(["--target", "process"])
             .arg("--out-dir")
             .arg(&output_directory)
             .output()
@@ -76,6 +77,30 @@ fn rejects_unsupported_dom_before_single_file_and_project_builds() {
         assert!(!stderr.contains("runtime defect"));
         assert!(!output_directory.exists());
     }
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn infers_web_for_a_single_file_with_a_browser_only_capability() {
+    let source = repository_root().join("crates/seseragi-cli/tests/fixtures/target-mismatch.ssrg");
+    let directory = test_directory("single-file-capability-target");
+    let output_directory = directory.join("artifact");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .arg("build")
+        .arg(source)
+        .arg("--out-dir")
+        .arg(&output_directory)
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output_directory.join("index.html").is_file());
     fs::remove_dir_all(directory).unwrap();
 }
 
@@ -145,6 +170,78 @@ fn builds_self_contained_web_outputs_for_single_files_and_projects() {
 }
 
 #[test]
+fn uses_the_manifest_target_unless_the_invocation_overrides_it() {
+    let root = repository_root();
+    let package = root.join("crates/seseragi-cli/tests/fixtures/web-project");
+    let manifest_path = package.join("seseragi.toml");
+    let manifest = fs::read(&manifest_path).unwrap();
+    let directory = test_directory("manifest-target");
+    let web_output = directory.join("web");
+
+    let selected = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .arg("build")
+        .arg(&package)
+        .arg("--out-dir")
+        .arg(&web_output)
+        .output()
+        .unwrap();
+    assert_eq!(
+        selected.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&selected.stderr)
+    );
+    assert!(web_output.join("index.html").is_file());
+
+    let inferred_package = directory.join("inferred-project");
+    fs::create_dir_all(inferred_package.join("src")).unwrap();
+    fs::write(
+        inferred_package.join("seseragi.toml"),
+        String::from_utf8(manifest.clone())
+            .unwrap()
+            .replace("target = \"web\"\n", ""),
+    )
+    .unwrap();
+    for source in ["main.ssrg", "counter.ssrg"] {
+        fs::copy(
+            package.join("src").join(source),
+            inferred_package.join("src").join(source),
+        )
+        .unwrap();
+    }
+    let inferred_output = directory.join("inferred");
+    let inferred = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .arg("build")
+        .arg(&inferred_package)
+        .arg("--out-dir")
+        .arg(&inferred_output)
+        .output()
+        .unwrap();
+    assert_eq!(
+        inferred.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&inferred.stderr)
+    );
+    assert!(inferred_output.join("index.html").is_file());
+
+    let process_output = directory.join("process");
+    let overridden = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .arg("build")
+        .arg(&package)
+        .args(["--target", "process"])
+        .arg("--out-dir")
+        .arg(&process_output)
+        .output()
+        .unwrap();
+    assert_eq!(overridden.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&overridden.stderr).contains("selected target: process"));
+    assert!(!process_output.exists());
+    assert_eq!(fs::read(manifest_path).unwrap(), manifest);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
 fn rejects_unknown_build_targets_without_creating_output() {
     let source = repository_root().join("examples/samples/hello-world/main.ssrg");
     let directory = test_directory("unknown-target");
@@ -160,7 +257,7 @@ fn rejects_unknown_build_targets_without_creating_output() {
 
     assert_eq!(output.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("unsupported build target `browser`; expected `process` or `web`"));
+        .contains("unknown project target `browser`; expected `process` or `web`"));
     assert!(!output_directory.exists());
     fs::remove_dir_all(directory).unwrap();
 }
@@ -196,6 +293,9 @@ fn builds_a_reproducible_single_file_program_that_matches_run() {
     ] {
         assert!(first_files.contains_key(required), "{required}");
     }
+    let marker =
+        String::from_utf8(first_files.get(".seseragi-build.json").unwrap().clone()).unwrap();
+    assert!(marker.contains("\"target\": \"process\""));
     let browser_dom = fs::read_to_string(
         output_directory.join("node_modules/@seseragi/runtime/src/browser/dom.ts"),
     )
@@ -310,6 +410,7 @@ fn builds_a_nested_multi_import_package_that_matches_run() {
         assert!(files.contains_key(required), "{required}");
     }
     let manifest = fs::read_to_string(output_directory.join(".seseragi-build.json")).unwrap();
+    assert!(manifest.contains("\"target\": \"process\""));
     assert!(manifest.contains("fixture/cli-build-nested@0.0.0::math/score"));
     assert!(manifest.contains("fixture/cli-build-nested@0.0.0::text/label"));
     assert!(manifest.contains("\"entryModule\""));

--- a/crates/seseragi-cli/tests/fixtures/target-mismatch-project/seseragi.toml
+++ b/crates/seseragi-cli/tests/fixtures/target-mismatch-project/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-web"
+target = "process"

--- a/crates/seseragi-cli/tests/fixtures/web-project/seseragi.toml
+++ b/crates/seseragi-cli/tests/fixtures/web-project/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-web"
+target = "web"

--- a/crates/seseragi-project/src/lib.rs
+++ b/crates/seseragi-project/src/lib.rs
@@ -15,6 +15,7 @@ mod package_name;
 mod source_import;
 mod specifier;
 mod standard;
+mod target;
 mod virtual_package;
 mod workspace;
 
@@ -65,6 +66,10 @@ pub use standard::{
     standard_module_status, standard_module_target, StandardHtmlTag, StandardHtmlTagKind,
     StandardModuleRegistrySurface, StandardModuleStatus, StandardModuleSurface,
     StandardPreludeBoundary, STANDARD_HTML_TAGS,
+};
+pub use target::{
+    select_project_target, ProjectCommand, ProjectTarget, TargetSelection, TargetSelectionError,
+    TargetSelectionSource,
 };
 pub use virtual_package::{
     load_virtual_package, LoadedVirtualPackage, VirtualPackageLoadError, VirtualPackageModule,

--- a/crates/seseragi-project/src/target.rs
+++ b/crates/seseragi-project/src/target.rs
@@ -120,13 +120,13 @@ pub fn select_project_target(
     manifest: Option<&TargetId>,
     compatible_targets: Option<&[ProjectTarget]>,
 ) -> Result<TargetSelection, TargetSelectionError> {
-    let manifest = manifest
-        .map(|target| ProjectTarget::parse(target.as_str()))
-        .transpose()?;
     let (target, source) = if let Some(target) = invocation {
         (target, TargetSelectionSource::Invocation)
     } else if let Some(target) = manifest {
-        (target, TargetSelectionSource::Manifest)
+        (
+            ProjectTarget::parse(target.as_str())?,
+            TargetSelectionSource::Manifest,
+        )
     } else if let Some([target]) = compatible_targets {
         (*target, TargetSelectionSource::Capabilities)
     } else {
@@ -227,6 +227,19 @@ mod tests {
             ),
             Err(TargetSelectionError::UnknownTarget(value)) if value == "bun-process"
         ));
+        assert_eq!(
+            select_project_target(
+                ProjectCommand::Build,
+                Some(ProjectTarget::Web),
+                Some(&target("bun-process")),
+                None,
+            )
+            .unwrap(),
+            TargetSelection {
+                target: ProjectTarget::Web,
+                source: TargetSelectionSource::Invocation,
+            }
+        );
         assert!(matches!(
             select_project_target(
                 ProjectCommand::Run,

--- a/crates/seseragi-project/src/target.rs
+++ b/crates/seseragi-project/src/target.rs
@@ -1,0 +1,271 @@
+use crate::TargetId;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProjectTarget {
+    Process,
+    Web,
+}
+
+impl ProjectTarget {
+    pub const ALL: [Self; 2] = [Self::Process, Self::Web];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::Web => "web",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, TargetSelectionError> {
+        match value {
+            "process" => Ok(Self::Process),
+            "web" => Ok(Self::Web),
+            _ => Err(TargetSelectionError::UnknownTarget(value.to_owned())),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProjectCommand {
+    Run,
+    Build,
+    Dev,
+}
+
+impl ProjectCommand {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Run => "run",
+            Self::Build => "build",
+            Self::Dev => "dev",
+        }
+    }
+
+    const fn default_target(self) -> ProjectTarget {
+        match self {
+            Self::Run | Self::Build => ProjectTarget::Process,
+            Self::Dev => ProjectTarget::Web,
+        }
+    }
+
+    const fn supports(self, target: ProjectTarget) -> bool {
+        match self {
+            Self::Run => matches!(target, ProjectTarget::Process),
+            Self::Build => true,
+            Self::Dev => matches!(target, ProjectTarget::Web),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TargetSelectionSource {
+    Invocation,
+    Manifest,
+    Capabilities,
+    CommandDefault,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TargetSelection {
+    pub target: ProjectTarget,
+    pub source: TargetSelectionSource,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TargetSelectionError {
+    UnknownTarget(String),
+    UnsupportedCommandTarget {
+        command: ProjectCommand,
+        target: ProjectTarget,
+    },
+    NoCompatibleTarget,
+    AmbiguousCapabilities(Vec<ProjectTarget>),
+}
+
+impl std::fmt::Display for TargetSelectionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownTarget(target) => write!(
+                formatter,
+                "unknown project target `{target}`; expected `process` or `web`"
+            ),
+            Self::UnsupportedCommandTarget { command, target } => write!(
+                formatter,
+                "{} does not support the `{}` target",
+                command.as_str(),
+                target.as_str()
+            ),
+            Self::NoCompatibleTarget => {
+                formatter.write_str("compiled program has no compatible project target")
+            }
+            Self::AmbiguousCapabilities(targets) => write!(
+                formatter,
+                "compiled program target is ambiguous: {}",
+                target_names(targets)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TargetSelectionError {}
+
+/// Selects one logical project target before provider resolution.
+///
+/// `compatible_targets` is `None` when compiled capability metadata is not
+/// available. An empty slice means metadata was available but no registered
+/// target can satisfy it.
+pub fn select_project_target(
+    command: ProjectCommand,
+    invocation: Option<ProjectTarget>,
+    manifest: Option<&TargetId>,
+    compatible_targets: Option<&[ProjectTarget]>,
+) -> Result<TargetSelection, TargetSelectionError> {
+    let manifest = manifest
+        .map(|target| ProjectTarget::parse(target.as_str()))
+        .transpose()?;
+    let (target, source) = if let Some(target) = invocation {
+        (target, TargetSelectionSource::Invocation)
+    } else if let Some(target) = manifest {
+        (target, TargetSelectionSource::Manifest)
+    } else if let Some([target]) = compatible_targets {
+        (*target, TargetSelectionSource::Capabilities)
+    } else {
+        let default = command.default_target();
+        match compatible_targets {
+            Some([]) => return Err(TargetSelectionError::NoCompatibleTarget),
+            Some(targets) if !targets.contains(&default) => {
+                return Err(TargetSelectionError::AmbiguousCapabilities(
+                    targets.to_vec(),
+                ));
+            }
+            _ => (default, TargetSelectionSource::CommandDefault),
+        }
+    };
+    if !command.supports(target) {
+        return Err(TargetSelectionError::UnsupportedCommandTarget { command, target });
+    }
+    Ok(TargetSelection { target, source })
+}
+
+fn target_names(targets: &[ProjectTarget]) -> String {
+    if targets.is_empty() {
+        "none".to_owned()
+    } else {
+        targets
+            .iter()
+            .map(|target| target.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(value: &str) -> TargetId {
+        TargetId::new(value.to_owned())
+    }
+
+    #[test]
+    fn applies_override_manifest_capability_and_command_precedence() {
+        assert_eq!(
+            select_project_target(
+                ProjectCommand::Build,
+                Some(ProjectTarget::Process),
+                Some(&target("web")),
+                Some(&ProjectTarget::ALL),
+            )
+            .unwrap(),
+            TargetSelection {
+                target: ProjectTarget::Process,
+                source: TargetSelectionSource::Invocation,
+            }
+        );
+        assert_eq!(
+            select_project_target(
+                ProjectCommand::Build,
+                None,
+                Some(&target("web")),
+                Some(&ProjectTarget::ALL),
+            )
+            .unwrap()
+            .source,
+            TargetSelectionSource::Manifest
+        );
+        assert_eq!(
+            select_project_target(
+                ProjectCommand::Build,
+                None,
+                None,
+                Some(&[ProjectTarget::Web]),
+            )
+            .unwrap(),
+            TargetSelection {
+                target: ProjectTarget::Web,
+                source: TargetSelectionSource::Capabilities,
+            }
+        );
+        assert_eq!(
+            select_project_target(ProjectCommand::Build, None, None, Some(&ProjectTarget::ALL),)
+                .unwrap(),
+            TargetSelection {
+                target: ProjectTarget::Process,
+                source: TargetSelectionSource::CommandDefault,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_adapter_ids_and_command_gaps() {
+        assert!(matches!(
+            select_project_target(
+                ProjectCommand::Build,
+                None,
+                Some(&target("bun-process")),
+                None,
+            ),
+            Err(TargetSelectionError::UnknownTarget(value)) if value == "bun-process"
+        ));
+        assert!(matches!(
+            select_project_target(
+                ProjectCommand::Run,
+                Some(ProjectTarget::Web),
+                None,
+                Some(&[ProjectTarget::Web]),
+            ),
+            Err(TargetSelectionError::UnsupportedCommandTarget { .. })
+        ));
+        assert_eq!(
+            select_project_target(
+                ProjectCommand::Build,
+                Some(ProjectTarget::Process),
+                None,
+                Some(&[ProjectTarget::Web]),
+            )
+            .unwrap()
+            .target,
+            ProjectTarget::Process
+        );
+    }
+
+    #[test]
+    fn keeps_the_phase_one_dev_policy_in_the_shared_resolver() {
+        assert_eq!(
+            select_project_target(ProjectCommand::Dev, None, None, None).unwrap(),
+            TargetSelection {
+                target: ProjectTarget::Web,
+                source: TargetSelectionSource::CommandDefault,
+            }
+        );
+        assert!(matches!(
+            select_project_target(
+                ProjectCommand::Dev,
+                Some(ProjectTarget::Process),
+                None,
+                None,
+            ),
+            Err(TargetSelectionError::UnsupportedCommandTarget { .. })
+        ));
+    }
+}

--- a/crates/seseragi-runtime/src/process/build.rs
+++ b/crates/seseragi-runtime/src/process/build.rs
@@ -16,6 +16,7 @@ const BUILD_MARKER: &str = concat!(
     "{\n",
     "  \"schema\": 1,\n",
     "  \"kind\": \"single-file\",\n",
+    "  \"target\": \"process\",\n",
     "  \"entry\": \"entry.ts\",\n",
     "  \"module\": \"main.ts\",\n",
     "  \"metadata\": \"generated-module.json\",\n",
@@ -191,6 +192,7 @@ pub fn build_local_project(
                 &ProjectBuildMarker {
                     schema: 1,
                     kind: "local-project",
+                    target: BuildTarget::Process.marker_target(),
                     entry: "entry.ts",
                     entry_module: &project.entry_module,
                     modules,
@@ -297,6 +299,7 @@ fn remove_optional_directory(path: &Path) -> Result<(), String> {
 struct ProjectBuildMarker<'entry> {
     schema: u32,
     kind: &'static str,
+    target: &'static str,
     entry: &'static str,
     entry_module: &'entry str,
     modules: Vec<ProjectBuildModule>,
@@ -484,7 +487,7 @@ fn is_managed_build(output_directory: &Path) -> bool {
             ownership.schema == 1
                 && ((ownership.entry == "entry.ts"
                     && ownership.runtime == "node_modules/@seseragi/runtime"
-                    && ownership.target.is_none()
+                    && matches!(ownership.target.as_deref(), None | Some("process"))
                     && matches!(ownership.kind.as_str(), "single-file" | "local-project"))
                     || (ownership.entry == "assets/app.js"
                         && ownership.runtime == "bundled"

--- a/docs/spec/11-packages-and-projects.md
+++ b/docs/spec/11-packages-and-projects.md
@@ -23,7 +23,7 @@ language = ">=0.1.0 <0.2.0"
 ```toml
 [run]
 entry = "main"
-target = "node"
+target = "process"
 signal_mode = "cancel"
 shutdown_grace_ms = 10000
 hash_seed = "entropy"
@@ -48,7 +48,7 @@ minimum_sample_ms = 100
 regression_threshold_percent = 5.0
 ```
 
-targetはCLI指定、`test.target`、`run.target`の順に選び、すべてなければtest開始前にtarget selection errorです。
+test targetはCLI指定、`test.target`、`run.target`の順に選び、すべてなければtest開始前にtarget selection errorです。
 jobsとtimeout_msは正の整数、cleanup_grace_msは0以上の整数、seedはsigned 64-bit integerです。省略時は
 jobs 1、timeout_ms 30000、cleanup_grace_ms 5000、seed 0です。
 CLIの対応optionはmanifest値をそのrunだけ上書きし、manifestやlockfileを書き換えません。
@@ -319,7 +319,9 @@ buildを拒否します。pure-load / task-loadの意味と同一identityを複�
 
 ## 11.10 executable entry
 
-`run.entry` はsource root内のmodule path、`run.target` はhost adapterの識別子です。
+`run.entry` はsource root内のmodule pathです。`run.target`はexecutable projectの既定logical targetです。
+現在のproduct commandは`process`または`web`を受理します。conformance toolが専用logical targetを持つことはできますが、
+Bun / Node / browser runtimeやprovider packageのidentityをここへ置きません。
 entry moduleは6.11の公開 `main` を一つ持たなければなりません。
 
 target IDとforeign resolver IDは `[a-z][a-z0-9-]*` に一致しなければなりません。
@@ -328,13 +330,34 @@ libraryとexecutableを兼ねるpackageは `exports` と `run` の両方を持�
 実行しようとするとerrorです。target固有optionは `[tool.<target>]` に置き、Seseragiの型やEffect
 semanticsを変更できません。
 
+`run`、`build`、`dev`、VS Code commandはproject layerの同じtarget resolverを使います。選択順は次です。
+
+1. invocationの`--target`等の一時override
+2. `run.target`のproject既定値
+3. commandが複数targetを実装済みなら、compiled `main`のrequired capabilityから候補が一つに絞れる場合はそのtarget
+4. command既定値（`run` / `build`は`process`、初期`dev`は`web`）
+
+CLI overrideはそのinvocationだけに適用し、manifest、lockfile、sourceを書き換えません。`[build]`や`[dev]`をtarget既定値の
+複製場所として追加しません。build markerとprovider selection metadataはresolverが選んだlogical targetを記録します。
+将来command固有設定が必要になってもtarget selectionはこのresolverへ戻します。
+
+required capabilityによるnarrowingは複数targetを実装済みのcommand（初期versionでは`build`）だけで行い、candidate targetから
+明らかに不可能なtargetを除くだけでproviderを選びません。単一target commandはそのtargetを選んで共通target diagnosticを返します。
+複数targetが成立する場合はcommand既定値が候補内ならそれを選び、既定値が候補外ならambiguity errorです。候補が0件なら
+target selection errorです。明示targetは推論で置き換えず、非互換なら#207のrequired / selected / missing / compatible payloadを
+持つ事前diagnosticを返します。logical target選択後にだけ15章のprovider resolverが具体adapter/provider artifactを選びます。
+
+初期`run`は`process`だけ、初期`dev`は`web`だけを実行可能とします。未対応のcommand / target組み合わせは実行前に拒否し、
+別targetへfallbackしません。`build`は両方を受理します。`web` buildはstatic browser application、`process` buildはCLIまたは
+HTTP serverを含むprocess applicationであり、HTTP service要求だけからstatic Web appへ分類しません。
+
 runnerは6.11のentry point規則に従い、entry moduleの公開 `main` を読み込み、匿名Unit値 `()` を
 一度渡してEffect valueを得ます。Effect valueはtarget adapterが用意したroot resource scopeで実行し、
 `main` のclosed environment requirementに必要なserviceだけを照合して供給します。actual host
 environmentは追加serviceを持てますが、required fieldを欠く場合や型が合わない場合はrun前のhost
 configuration errorです。
 
-CLIの`run`と既定の`build`は`process` targetを選びます。runnerはentry生成や一時directory作成より前に、
+CLIの`run`と`build`は上記resolverの選択targetを使います。runnerはentry生成や一時directory作成より前に、
 closed environment requirementを中央target registryと照合します。`process` targetがProvider選択なしで
 直接提供するbaseline capabilityは`console`と`stdin`です。Clock、HTTP、filesystem等のProvider-backed
 serviceは15章のresolution結果を同じenvironmentへ追加し、target builtin一覧へ重複登録しません。

--- a/docs/spec/11-packages-and-projects.md
+++ b/docs/spec/11-packages-and-projects.md
@@ -338,8 +338,8 @@ semanticsを変更できません。
 4. command既定値（`run` / `build`は`process`、初期`dev`は`web`）
 
 CLI overrideはそのinvocationだけに適用し、manifest、lockfile、sourceを書き換えません。`[build]`や`[dev]`をtarget既定値の
-複製場所として追加しません。build markerとprovider selection metadataはresolverが選んだlogical targetを記録します。
-将来command固有設定が必要になってもtarget selectionはこのresolverへ戻します。
+複製場所として追加しません。build markerはresolverが選んだlogical targetを記録し、provider selection metadataはそこから
+toolchainが写像したadapter targetを記録します。将来command固有設定が必要になってもtarget selectionはこのresolverへ戻します。
 
 required capabilityによるnarrowingは複数targetを実装済みのcommand（初期versionでは`build`）だけで行い、candidate targetから
 明らかに不可能なtargetを除くだけでproviderを選びません。単一target commandはそのtargetを選んで共通target diagnosticを返します。

--- a/docs/spec/15-runtime-providers.md
+++ b/docs/spec/15-runtime-providers.md
@@ -253,6 +253,10 @@ provider identityは`<package name>#<kebab-name>`です。package versionとsour
 package identityから得るため、identity文字列へversionを埋めません。同じresolved package内でidentityは一意で、
 一つのartifactは一つの`service`だけを提供します。複数serviceを実装するpackageはartifactを分けます。
 
+11.10のproject target resolverが選ぶ`process` / `web`はapplicationとcommandのlogical targetです。provider manifestの
+`targets`にある`bun-process`等はtoolchain adapter identityで、logical target選択後にtoolchainが対応adapterへ写像します。
+target selectionとprovider selectionを同一のfallback処理へ統合せず、provider不足を別logical targetへの切替で隠しません。
+
 - `service`: 15.2のContract identity。
 - `contractVersion`: providerが実装するservice Contractのmajor / minor。
 - `backend`: backend familyと、そのbackend Runtime ABI major。

--- a/examples/spec/artifacts/project-schema-1/rock-paper-scissors-cli-split/seseragi.toml
+++ b/examples/spec/artifacts/project-schema-1/rock-paper-scissors-cli-split/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "process"

--- a/examples/spec/fixtures/projects/cli-build-nested/seseragi.toml
+++ b/examples/spec/fixtures/projects/cli-build-nested/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "process"

--- a/examples/spec/fixtures/projects/entry-rooted-runtime/seseragi.toml
+++ b/examples/spec/fixtures/projects/entry-rooted-runtime/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "process"

--- a/examples/spec/fixtures/projects/logical-short-circuit/seseragi.toml
+++ b/examples/spec/fixtures/projects/logical-short-circuit/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "process"

--- a/examples/spec/fixtures/projects/module-generic-nominal-identity/seseragi.toml
+++ b/examples/spec/fixtures/projects/module-generic-nominal-identity/seseragi.toml
@@ -5,7 +5,7 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "web"
 
 [dependencies]
 ui = { package = "fixture/module-generic-nominal-ui", path = "vendor/ui" }

--- a/examples/spec/fixtures/projects/package-path-dependency-basic/seseragi.toml
+++ b/examples/spec/fixtures/projects/package-path-dependency-basic/seseragi.toml
@@ -5,7 +5,7 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "process"
 
 [dependencies]
 math = { package = "fixture/math-basic", path = "vendor/math" }

--- a/examples/spec/fixtures/projects/package-path-dependency/seseragi.toml
+++ b/examples/spec/fixtures/projects/package-path-dependency/seseragi.toml
@@ -5,7 +5,7 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "process"
 
 [dependencies]
 math = { package = "fixture/math", path = "vendor/math" }

--- a/examples/spec/fixtures/projects/provider-http-server-e2e/seseragi.toml
+++ b/examples/spec/fixtures/projects/provider-http-server-e2e/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "bun-process"
+target = "process"

--- a/examples/spec/fixtures/projects/struct-field-generic-identity/seseragi.toml
+++ b/examples/spec/fixtures/projects/struct-field-generic-identity/seseragi.toml
@@ -5,4 +5,4 @@ language = ">=0.1.0 <0.2.0"
 
 [run]
 entry = "main"
-target = "test-js"
+target = "web"


### PR DESCRIPTION
## Summary

- add one project-layer target resolver shared by run/build and ready for dev/VS Code consumers
- define invocation override > manifest default > capability narrowing > command default precedence
- separate logical process/web targets from provider adapter identities and keep provider resolution after target selection
- make package and single-file builds respect/infer the same target contract and record it in build markers
- migrate current product-route fixtures to process/web while preserving contract-only conformance adapter IDs

## Validation

- `bun run check:rust`
- `bun run check:conformance`
- `cargo test -p seseragi-cli --test build`
- `cargo test -p seseragi-cli --test run`
- `bun run fixtures:check`
- `git diff --check`

Closes #364