### PR TITLE
Add Web project dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bun.lock
 
 # Build outputs
 dist/
+.seseragi/
 target/
 apps/playground/test-results/
 extensions/seseragi/LICENSE.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +28,35 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -166,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +226,33 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -284,6 +361,7 @@ dependencies = [
 name = "seseragi-cli"
 version = "0.4.7"
 dependencies = [
+ "ctrlc",
  "seseragi-driver",
  "seseragi-project",
  "seseragi-release",
@@ -618,6 +696,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/seseragi-cli/Cargo.toml
+++ b/crates/seseragi-cli/Cargo.toml
@@ -10,6 +10,7 @@ name = "seseragi"
 path = "src/main.rs"
 
 [dependencies]
+ctrlc = "3.4"
 seseragi-driver = { path = "../seseragi-driver" }
 seseragi-project = { path = "../seseragi-project" }
 seseragi-release = { path = "../seseragi-release" }

--- a/crates/seseragi-cli/src/dev.rs
+++ b/crates/seseragi-cli/src/dev.rs
@@ -1,0 +1,467 @@
+use crate::local_project::{compile_path, LocalProjectCompilation};
+use seseragi_project::ProjectCommand;
+use seseragi_runtime::{build_local_project, BuildTarget};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
+
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_PORT: u16 = 3000;
+const RELOAD_PATH: &str = "/__seseragi_dev/version";
+const WATCH_INTERVAL: Duration = Duration::from_millis(100);
+
+pub(crate) fn dev(arguments: &[String]) -> Result<i32, String> {
+    let options = DevOptions::parse(arguments)?;
+    if !options.path.is_dir() {
+        return Err("dev requires a package directory".to_owned());
+    }
+    let project = options.path.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve package {}: {error}",
+            options.path.display()
+        )
+    })?;
+    let output = project.join(".seseragi/dev");
+    let listener = TcpListener::bind((options.host.as_str(), options.port)).map_err(|error| {
+        format!(
+            "dev server could not bind {}:{}: {error}",
+            options.host, options.port
+        )
+    })?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("failed to configure dev server: {error}"))?;
+    let address = listener
+        .local_addr()
+        .map_err(|error| format!("failed to read dev server address: {error}"))?;
+    let url = format!("http://{}:{}/", options.host, address.port());
+
+    let stopping = Arc::new(AtomicBool::new(false));
+    let signal = Arc::clone(&stopping);
+    ctrlc::set_handler(move || signal.store(true, Ordering::SeqCst))
+        .map_err(|error| format!("failed to install shutdown handler: {error}"))?;
+
+    let mut watch_roots = watched_package_roots(&project).unwrap_or_else(|_| vec![project.clone()]);
+    let mut files = watch_snapshot(&watch_roots)?;
+    let version = AtomicU64::new(0);
+    let mut build_available = rebuild(&project, &output, &version)?;
+    println!("Dev server: {url}");
+    println!("Watching {}", project.display());
+    if options.open {
+        open_browser(&url)?;
+    }
+
+    while !stopping.load(Ordering::SeqCst) {
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    if let Err(error) = serve(stream, &output, &version, build_available) {
+                        eprintln!("seseragi dev: {error}");
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                Err(error) => return Err(format!("dev server accept failed: {error}")),
+            }
+        }
+
+        let next = watch_snapshot(&watch_roots)?;
+        if next != files {
+            let rebuilt = match rebuild(&project, &output, &version) {
+                Ok(rebuilt) => rebuilt,
+                Err(error) => {
+                    eprintln!("seseragi dev: {error}");
+                    eprintln!("Build failed");
+                    false
+                }
+            };
+            build_available = rebuilt || build_available;
+            if rebuilt {
+                watch_roots = watched_package_roots(&project)?;
+            }
+            files = watch_snapshot(&watch_roots)?;
+        }
+        std::thread::sleep(WATCH_INTERVAL);
+    }
+    println!("Stopped dev server");
+    Ok(0)
+}
+
+struct DevOptions {
+    path: PathBuf,
+    host: String,
+    port: u16,
+    open: bool,
+}
+
+impl DevOptions {
+    fn parse(arguments: &[String]) -> Result<Self, String> {
+        let mut path = None;
+        let mut host = DEFAULT_HOST.to_owned();
+        let mut port = DEFAULT_PORT;
+        let mut open = false;
+        let mut index = 0;
+        while index < arguments.len() {
+            match arguments[index].as_str() {
+                "--host" => {
+                    index += 1;
+                    host = arguments
+                        .get(index)
+                        .filter(|value| !value.is_empty())
+                        .ok_or_else(|| "--host requires an address".to_owned())?
+                        .clone();
+                }
+                "--port" => {
+                    index += 1;
+                    let value = arguments
+                        .get(index)
+                        .ok_or_else(|| "--port requires a number".to_owned())?;
+                    port = value
+                        .parse::<u16>()
+                        .map_err(|_| format!("invalid dev port `{value}`"))?;
+                }
+                "--open" => open = true,
+                argument if argument.starts_with('-') => {
+                    return Err(format!("unknown dev option `{argument}`"));
+                }
+                argument if path.is_none() => path = Some(PathBuf::from(argument)),
+                argument => return Err(format!("unexpected dev argument `{argument}`")),
+            }
+            index += 1;
+        }
+        Ok(Self {
+            path: path.unwrap_or_else(|| PathBuf::from(".")),
+            host,
+            port,
+            open,
+        })
+    }
+}
+
+fn rebuild(project: &Path, output: &Path, version: &AtomicU64) -> Result<bool, String> {
+    let started = Instant::now();
+    let compiled = match compile_path(project, ProjectCommand::Dev, None)? {
+        LocalProjectCompilation::Compiled(compiled) => compiled,
+        LocalProjectCompilation::Diagnostics => {
+            eprintln!("Build failed ({})", elapsed(started));
+            return Ok(false);
+        }
+    };
+    build_local_project(&compiled.compiled, output, BuildTarget::Web)
+        .map_err(|error| error.to_string())?;
+    let next = version.fetch_add(1, Ordering::SeqCst) + 1;
+    println!("Built web app ({}; reload {next})", elapsed(started));
+    Ok(true)
+}
+
+fn elapsed(started: Instant) -> String {
+    format!("{} ms", started.elapsed().as_millis())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WatchStamp {
+    modified: Option<SystemTime>,
+    length: u64,
+    fingerprint: u64,
+}
+
+fn watched_package_roots(project: &Path) -> Result<Vec<PathBuf>, String> {
+    let graph = seseragi_project::discover_local_package_graph(project)
+        .map_err(|error| format!("{}: {error}", error.code()))?;
+    Ok(graph
+        .packages()
+        .map(|(_, package)| package.root().to_owned())
+        .collect())
+}
+
+fn watch_snapshot(roots: &[PathBuf]) -> Result<BTreeMap<PathBuf, WatchStamp>, String> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        files: &mut BTreeMap<PathBuf, WatchStamp>,
+    ) -> Result<(), String> {
+        for entry in fs::read_dir(directory)
+            .map_err(|error| format!("failed to watch {}: {error}", directory.display()))?
+        {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "failed to read watched directory {}: {error}",
+                    directory.display()
+                )
+            })?;
+            let path = entry.path();
+            let relative = path.strip_prefix(root).expect("watched path is under root");
+            if ignored(relative) {
+                continue;
+            }
+            let metadata = entry.metadata().map_err(|error| {
+                format!("failed to inspect watched path {}: {error}", path.display())
+            })?;
+            if metadata.is_dir() {
+                visit(root, &path, files)?;
+            } else if watched(relative) {
+                let fingerprint = fingerprint(&path)?;
+                files.insert(
+                    path,
+                    WatchStamp {
+                        modified: metadata.modified().ok(),
+                        length: metadata.len(),
+                        fingerprint,
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+
+    let mut files = BTreeMap::new();
+    for root in roots {
+        visit(root, root, &mut files)?;
+    }
+    Ok(files)
+}
+
+fn fingerprint(path: &Path) -> Result<u64, String> {
+    let bytes = fs::read(path)
+        .map_err(|error| format!("failed to read watched path {}: {error}", path.display()))?;
+    Ok(bytes.into_iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+    }))
+}
+
+fn ignored(path: &Path) -> bool {
+    matches!(
+        path.components().next(),
+        Some(Component::Normal(name))
+            if name == ".git" || name == ".seseragi" || name == "dist" || name == "node_modules"
+    )
+}
+
+fn watched(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some("seseragi.toml")
+        || path.extension().and_then(|extension| extension.to_str()) == Some("ssrg")
+}
+
+fn serve(
+    mut stream: TcpStream,
+    output: &Path,
+    version: &AtomicU64,
+    build_available: bool,
+) -> Result<(), String> {
+    stream
+        .set_read_timeout(Some(Duration::from_millis(100)))
+        .map_err(|error| format!("failed to configure client: {error}"))?;
+    let mut request = [0_u8; 8192];
+    let length = match stream.read(&mut request) {
+        Ok(0) => return Ok(()),
+        Ok(length) => length,
+        Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+            return Ok(())
+        }
+        Err(error) => return Err(format!("failed to read request: {error}")),
+    };
+    let request = String::from_utf8_lossy(&request[..length]);
+    let Some(line) = request.lines().next() else {
+        return Ok(());
+    };
+    let mut parts = line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let request_path = parts.next().unwrap_or("");
+    if !matches!(method, "GET" | "HEAD") {
+        return response(
+            &mut stream,
+            405,
+            "text/plain; charset=utf-8",
+            b"Method not allowed\n",
+            method,
+        );
+    }
+    let request_path = request_path.split('?').next().unwrap_or(request_path);
+    if request_path == RELOAD_PATH {
+        let body = format!("{}\n", version.load(Ordering::SeqCst));
+        return response(
+            &mut stream,
+            200,
+            "text/plain; charset=utf-8",
+            body.as_bytes(),
+            method,
+        );
+    }
+    if !build_available {
+        let body = inject_reload(
+            b"<!doctype html><title>Seseragi build failed</title><body><h1>Build failed</h1><p>Fix the compiler diagnostics; this page will become available after the next successful build.</p></body>",
+        );
+        return response(&mut stream, 503, "text/html; charset=utf-8", &body, method);
+    }
+    let relative = safe_path(request_path).ok_or_else(|| "invalid request path".to_owned())?;
+    let path = output.join(&relative);
+    let metadata = fs::metadata(&path).ok();
+    let path = if metadata.as_ref().is_some_and(|value| value.is_file()) {
+        path
+    } else if !relative.to_string_lossy().contains('.') {
+        output.join("index.html")
+    } else {
+        return response(
+            &mut stream,
+            404,
+            "text/plain; charset=utf-8",
+            b"Not found\n",
+            method,
+        );
+    };
+    let mut body =
+        fs::read(&path).map_err(|error| format!("failed to serve {}: {error}", path.display()))?;
+    if path.file_name().and_then(|name| name.to_str()) == Some("index.html") {
+        body = inject_reload(&body);
+    }
+    response(&mut stream, 200, content_type(&path), &body, method)
+}
+
+fn safe_path(request_path: &str) -> Option<PathBuf> {
+    let trimmed = request_path.trim_start_matches('/');
+    let path = if trimmed.is_empty() {
+        "index.html"
+    } else {
+        trimmed
+    };
+    let path = Path::new(path);
+    if path
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        Some(path.to_owned())
+    } else {
+        None
+    }
+}
+
+fn inject_reload(index: &[u8]) -> Vec<u8> {
+    const SCRIPT: &str = concat!(
+        "<script type=\"module\">\n",
+        "const endpoint = '/__seseragi_dev/version';\n",
+        "let version = await (await fetch(endpoint, { cache: 'no-store' })).text();\n",
+        "setInterval(async () => {\n",
+        "  try {\n",
+        "    const next = await (await fetch(endpoint, { cache: 'no-store' })).text();\n",
+        "    if (next !== version) location.reload();\n",
+        "  } catch {}\n",
+        "}, 250);\n",
+        "</script>\n",
+    );
+    let source = String::from_utf8_lossy(index);
+    if let Some(position) = source.rfind("</body>") {
+        let mut output = String::with_capacity(source.len() + SCRIPT.len());
+        output.push_str(&source[..position]);
+        output.push_str(SCRIPT);
+        output.push_str(&source[position..]);
+        output.into_bytes()
+    } else {
+        [index, SCRIPT.as_bytes()].concat()
+    }
+}
+
+fn content_type(path: &Path) -> &'static str {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("html") => "text/html; charset=utf-8",
+        Some("js") => "text/javascript; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("map") | Some("json") => "application/json; charset=utf-8",
+        Some("svg") => "image/svg+xml",
+        Some("png") => "image/png",
+        _ => "application/octet-stream",
+    }
+}
+
+fn response(
+    stream: &mut TcpStream,
+    status: u16,
+    content_type: &str,
+    body: &[u8],
+    method: &str,
+) -> Result<(), String> {
+    let reason = match status {
+        200 => "OK",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        503 => "Service Unavailable",
+        _ => "Error",
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .and_then(|()| {
+        if method == "HEAD" {
+            Ok(())
+        } else {
+            stream.write_all(body)
+        }
+    })
+    .map_err(|error| format!("failed to write response: {error}"))
+}
+
+fn open_browser(url: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let mut command = Command::new("open");
+    #[cfg(target_os = "linux")]
+    let mut command = Command::new("xdg-open");
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "start", ""]);
+        command
+    };
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    return Err("--open is not supported on this host".to_owned());
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    command
+        .arg(url)
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| format!("failed to open browser: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_options_and_rejects_invalid_ports() {
+        let options = DevOptions::parse(&[
+            "app".to_owned(),
+            "--host".to_owned(),
+            "0.0.0.0".to_owned(),
+            "--port".to_owned(),
+            "4000".to_owned(),
+            "--open".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(options.path, Path::new("app"));
+        assert_eq!(options.host, "0.0.0.0");
+        assert_eq!(options.port, 4000);
+        assert!(options.open);
+        assert!(DevOptions::parse(&["--port".to_owned(), "nope".to_owned()]).is_err());
+    }
+
+    #[test]
+    fn confines_static_paths_and_injects_reload_client() {
+        assert_eq!(
+            safe_path("/assets/app.js"),
+            Some(PathBuf::from("assets/app.js"))
+        );
+        assert_eq!(safe_path("/"), Some(PathBuf::from("index.html")));
+        assert_eq!(safe_path("/../secret"), None);
+        let index = inject_reload(b"<body>app</body>");
+        let index = String::from_utf8(index).unwrap();
+        assert!(index.contains(RELOAD_PATH));
+        assert!(index.ends_with("</body>"));
+        let failed = inject_reload(b"<body>Build failed</body>");
+        assert!(String::from_utf8(failed).unwrap().contains(RELOAD_PATH));
+    }
+}

--- a/crates/seseragi-cli/src/main.rs
+++ b/crates/seseragi-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod build;
+mod dev;
 mod format;
 mod local_project;
 mod run;
@@ -19,6 +20,7 @@ fn run(arguments: impl IntoIterator<Item = String>) -> Result<i32, String> {
     match arguments.as_slice() {
         [command, path] if command == "run" => run::run_path(path.as_ref()),
         [command, arguments @ ..] if command == "build" => build::build(arguments),
+        [command, arguments @ ..] if command == "dev" => dev::dev(arguments),
         [command, path] if command == "format" => {
             format::format_file(path.as_ref(), format::FormatMode::Write)
         }
@@ -39,6 +41,6 @@ fn run(arguments: impl IntoIterator<Item = String>) -> Result<i32, String> {
 
 fn print_usage() {
     println!(
-        "Usage:\n  seseragi --version\n  seseragi run path/to/app.ssrg\n  seseragi run path/to/package\n  seseragi build path/to/app.ssrg [--target process|web] [--out-dir path/to/dist]\n  seseragi build path/to/package [--target process|web] [--out-dir path/to/dist]\n  seseragi format [--check] path/to/app.ssrg"
+        "Usage:\n  seseragi --version\n  seseragi run path/to/app.ssrg\n  seseragi run path/to/package\n  seseragi build path/to/app.ssrg [--target process|web] [--out-dir path/to/dist]\n  seseragi build path/to/package [--target process|web] [--out-dir path/to/dist]\n  seseragi dev [path/to/package] [--host 127.0.0.1] [--port 3000] [--open]\n  seseragi format [--check] path/to/app.ssrg"
     );
 }

--- a/crates/seseragi-cli/tests/dev.rs
+++ b/crates/seseragi-cli/tests/dev.rs
@@ -1,0 +1,278 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn test_directory(name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let directory = std::env::temp_dir().join(format!(
+        "seseragi-dev-{name}-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&directory).unwrap();
+    directory
+}
+
+fn copy_directory(source: &Path, destination: &Path) {
+    fs::create_dir_all(destination).unwrap();
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let target = destination.join(entry.file_name());
+        if path.is_dir() {
+            copy_directory(&path, &target);
+        } else {
+            fs::copy(path, target).unwrap();
+        }
+    }
+}
+
+fn available_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn request(port: u16, path: &str) -> Option<(u16, String)> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    )
+    .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    let status = response
+        .lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()?;
+    let body = response.split_once("\r\n\r\n")?.1.to_owned();
+    Some((status, body))
+}
+
+fn wait_for(timeout: Duration, mut condition: impl FnMut() -> bool, message: &str) {
+    let started = Instant::now();
+    while started.elapsed() < timeout {
+        if condition() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for {message}");
+}
+
+fn stop(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let status = Command::new("kill")
+            .args(["-INT", &child.id().to_string()])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        wait_for(
+            Duration::from_secs(5),
+            || child.try_wait().unwrap().is_some(),
+            "graceful dev shutdown",
+        );
+        assert!(child.wait().unwrap().success());
+    }
+    #[cfg(not(unix))]
+    {
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+}
+
+#[test]
+fn serves_rebuilds_recovers_and_shuts_down_a_canonical_web_project() {
+    let directory = test_directory("lifecycle");
+    let project = directory.join("project-flow-app");
+    copy_directory(
+        &repository_root().join("examples/samples/project-flow-app"),
+        &project,
+    );
+    let log = fs::File::create(directory.join("dev.log")).unwrap();
+    let port = available_port();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .args([
+            "dev",
+            project.to_str().unwrap(),
+            "--port",
+            &port.to_string(),
+        ])
+        .stdout(Stdio::from(log.try_clone().unwrap()))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .unwrap();
+
+    wait_for(
+        Duration::from_secs(20),
+        || request(port, "/").is_some_and(|response| response.0 == 200),
+        "initial web build",
+    );
+    let (_, index) = request(port, "/").unwrap();
+    assert!(index.contains("/__seseragi_dev/version"));
+    let (_, source_map) = request(port, "/assets/app.js.map").unwrap();
+    assert!(source_map.contains("sources"));
+    let initial_version = request(port, "/__seseragi_dev/version").unwrap().1;
+    let production_output = project.join("dist");
+    assert!(!production_output.exists());
+
+    let source_path = project.join("src/app.ssrg");
+    let original = fs::read_to_string(&source_path).unwrap();
+    let changed = original.replace(
+        "Make room for the next release.",
+        "Make room for the next live release.",
+    );
+    fs::write(&source_path, &changed).unwrap();
+    wait_for(
+        Duration::from_secs(20),
+        || {
+            request(port, "/__seseragi_dev/version")
+                .is_some_and(|response| response.1 != initial_version)
+        },
+        "successful rebuild",
+    );
+    let rebuilt_version = request(port, "/__seseragi_dev/version").unwrap().1;
+    let (_, bundle) = request(port, "/assets/app.js").unwrap();
+    assert!(bundle.contains("Make room for the next live release."));
+
+    fs::write(&source_path, format!("{changed}\nmissingDevName\n")).unwrap();
+    thread::sleep(Duration::from_secs(2));
+    assert_eq!(
+        request(port, "/__seseragi_dev/version").unwrap().1,
+        rebuilt_version
+    );
+    assert_eq!(request(port, "/").unwrap().0, 200);
+    assert!(child.try_wait().unwrap().is_none());
+
+    fs::write(&source_path, &changed).unwrap();
+    wait_for(
+        Duration::from_secs(20),
+        || {
+            request(port, "/__seseragi_dev/version")
+                .is_some_and(|response| response.1 != rebuilt_version)
+        },
+        "recovery rebuild",
+    );
+    stop(&mut child);
+
+    let log = fs::read_to_string(directory.join("dev.log")).unwrap();
+    assert!(log.contains("Built web app"));
+    assert!(log.contains("error[SES-N0001]"), "{log}");
+    assert!(log.contains("Build failed"));
+    assert!(log.contains("Stopped dev server"));
+    assert!(!production_output.exists());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn reports_port_conflicts_without_starting_a_second_server() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let package = repository_root().join("examples/samples/project-flow-app");
+    let output = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .args([
+            "dev",
+            package.to_str().unwrap(),
+            "--port",
+            &port.to_string(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("dev server could not bind"), "{stderr}");
+    assert!(stderr.contains(&port.to_string()), "{stderr}");
+}
+
+#[test]
+fn recovers_when_the_initial_build_has_compiler_diagnostics() {
+    let directory = test_directory("initial-failure");
+    let project = directory.join("project-flow-app");
+    copy_directory(
+        &repository_root().join("examples/samples/project-flow-app"),
+        &project,
+    );
+    let source_path = project.join("src/app.ssrg");
+    let source = fs::read_to_string(&source_path).unwrap();
+    fs::write(&source_path, format!("{source}\nmissingInitialDevName\n")).unwrap();
+    let log = fs::File::create(directory.join("dev.log")).unwrap();
+    let port = available_port();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .args([
+            "dev",
+            project.to_str().unwrap(),
+            "--port",
+            &port.to_string(),
+        ])
+        .stdout(Stdio::from(log.try_clone().unwrap()))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .unwrap();
+
+    wait_for(
+        Duration::from_secs(10),
+        || request(port, "/").is_some_and(|response| response.0 == 503),
+        "initial diagnostic fallback",
+    );
+    let (_, fallback) = request(port, "/").unwrap();
+    assert!(fallback.contains("Build failed"));
+    assert!(fallback.contains("/__seseragi_dev/version"));
+    assert!(child.try_wait().unwrap().is_none());
+
+    fs::write(&source_path, source).unwrap();
+    wait_for(
+        Duration::from_secs(20),
+        || request(port, "/").is_some_and(|response| response.0 == 200),
+        "first successful build after diagnostics",
+    );
+    stop(&mut child);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn rejects_process_target_packages_before_entering_the_watch_loop() {
+    let package = repository_root().join("examples/spec/fixtures/projects/std-parity-portable");
+    let output = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .args(["dev", package.to_str().unwrap(), "--port", "0"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("dev does not support the `process` target"));
+}
+
+#[test]
+fn documents_dev_in_cli_help() {
+    let output = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .arg("--help")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("seseragi dev [path/to/package]"));
+    assert!(stdout.contains("--host 127.0.0.1"));
+    assert!(stdout.contains("--port 3000"));
+    assert!(stdout.contains("--open"));
+}

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -955,6 +955,16 @@ single-file fallback、LSP hover/completion、WASM Analyze/Compile、Playground 
 `std-parity-target`はprocessでDOMを要求し、CLIとWASM Analyze/Compileが同じ
 `SES-K0203 provider.target-mismatch` contractを返すnegative product routeです。
 
+`seseragi dev`はlocal Web packageのhost toolingとして、同じ
+`ProjectCommand::Dev` target resolver、browser provider resolution、
+`build_local_project(..., Web)`を再利用します。成果物はpackage内のmanaged
+`.seseragi/dev`へatomic publishし、localhost static serverがlinked source mapとともに
+配信します。source / manifest変更は初期版ではfull project rebuildし、成功時だけreload
+versionを進めます。compile failure中はserverと最後の成功buildを維持し、配信時だけ
+reload clientを`index.html`へ注入するため、production `seseragi build`のartifactとruntime
+dependencyは変更しません。SIGINTはwatch loopとlistenerを閉じ、`--host` / `--port` /
+`--open`はhost toolingだけが所有します。
+
 `schema-1/monad-laws`はFunctor identity / composition、Applicative identity / homomorphism、Monad left identity /
 right identity / associativityを一つの小さいuser-defined Maybe instance群で表現します。
 `execution-schema-1/monad-laws`は七つの比較結果をConsole traceとstdoutまで固定し、selected dictionary、supertrait

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -457,6 +457,12 @@ canonical registry、lowering/runtime実装inventory、public interface fingerpr
 検証します。target差は同一negative packageからCLIとWASM Analyze/Compileへ
 `SES-K0203 provider.target-mismatch`として運びます。contract-only entryはこのgateの実装証拠に含めません。
 
+local Web packageは`seseragi dev`で通常のfilesystem projectをbuild、watch、static serveできます。
+既存Web target resolverとproduction build pathを共有し、managed `.seseragi/dev`からsource mapを配信します。
+source / manifest変更後はfull reloadし、compile error中もserverと最後の成功buildを維持、修正後に復旧します。
+canonical `project-flow-app`の実process E2Eがinitial render artifact、rebuild、error recovery、port conflict、
+SIGINT cleanupを固定し、実browserでもrender、interaction、stateを初期化するreloadを確認しています。
+
 Playground-1は`apps/playground`へCodeMirror 6、専用Seseragi highlight、mobile panel、任意Stdin、
 driver diagnosticsのsource range表示を実装しました。Vercel buildはreview済みWASM artifactを静的bundleするため
 Rust installを要求しません。Rust移行完了後に旧React / Monaco Playgroundは削除し、

--- a/examples/samples/project-flow-app/guide.md
+++ b/examples/samples/project-flow-app/guide.md
@@ -17,6 +17,18 @@ seseragi build . --out-dir dist
 `seseragi.toml`の`run.target = "web"`がWeb buildを選びます。Playgroundも同じ
 manifestと`src/`のsource treeを読み込むため、CLI用のsource copyはありません。
 
+通常開発ではpackage rootから`seseragi dev`を起動すると、同じWeb target resolverと
+production build semanticsを使って`.seseragi/dev`へbuildし、localhostで配信します。
+`src/**/*.ssrg`または`seseragi.toml`を保存するとfull project rebuild後にbrowserを
+reloadします。compile error中もserverと最後の成功buildは維持され、修正すると自動で
+復旧します。
+
+```sh
+seseragi dev --open
+```
+
+既定は`127.0.0.1:3000`です。共有開発環境では`--host`と`--port`を明示できます。
+
 ## まずExplorerで読む順番
 
 1. `app.ssrg` を開きます。ここはshellのvisual state、fixed image / document


### PR DESCRIPTION
## Summary

- add `seseragi dev` for manifest-backed Web packages using the shared `ProjectCommand::Dev` target resolver and production Web build path
- serve managed `.seseragi/dev` output with source maps, full-page reload, host/port/open options, and graceful SIGINT cleanup
- keep the server and last successful artifact alive through compiler diagnostics, including recovery from an initially broken package
- watch the complete local path-dependency graph and refresh it after manifest changes
- document the local Web development loop on the canonical `project-flow-app`

## Impact

- reload code is injected only by the dev HTTP server; production `seseragi build` artifacts are unchanged
- the first release supports only Web targets and full reload, as scoped by the issue

## Verification

- `cargo test -p seseragi-cli`
- `bun run check:rust -- -p seseragi-cli`
- `bun run check:sample`
- real-browser QA on canonical `project-flow-app`: initial render, interaction, edit/rebuild/full reload, compiler-error server continuity, recovery
- `bun run check` (queue integration gate; all checks passed)

Closes #365
