### PR TITLE
Add VS Code project commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ name = "seseragi-cli"
 version = "0.4.7"
 dependencies = [
  "ctrlc",
+ "serde_json",
  "seseragi-driver",
  "seseragi-project",
  "seseragi-release",

--- a/crates/seseragi-cli/Cargo.toml
+++ b/crates/seseragi-cli/Cargo.toml
@@ -15,3 +15,4 @@ seseragi-driver = { path = "../seseragi-driver" }
 seseragi-project = { path = "../seseragi-project" }
 seseragi-release = { path = "../seseragi-release" }
 seseragi-runtime = { path = "../seseragi-runtime" }
+serde_json.workspace = true

--- a/crates/seseragi-cli/src/main.rs
+++ b/crates/seseragi-cli/src/main.rs
@@ -31,6 +31,14 @@ fn run(arguments: impl IntoIterator<Item = String>) -> Result<i32, String> {
             println!("{}", seseragi_release::format_human_version("seseragi"));
             Ok(0)
         }
+        [flag] if flag == "--version-json" => {
+            println!(
+                "{}",
+                serde_json::to_string(&seseragi_release::build_metadata("seseragi"))
+                    .map_err(|error| format!("failed to encode version metadata: {error}"))?
+            );
+            Ok(0)
+        }
         [flag] if flag == "--help" || flag == "-h" => {
             print_usage();
             Ok(0)
@@ -41,6 +49,6 @@ fn run(arguments: impl IntoIterator<Item = String>) -> Result<i32, String> {
 
 fn print_usage() {
     println!(
-        "Usage:\n  seseragi --version\n  seseragi run path/to/app.ssrg\n  seseragi run path/to/package\n  seseragi build path/to/app.ssrg [--target process|web] [--out-dir path/to/dist]\n  seseragi build path/to/package [--target process|web] [--out-dir path/to/dist]\n  seseragi dev [path/to/package] [--host 127.0.0.1] [--port 3000] [--open]\n  seseragi format [--check] path/to/app.ssrg"
+        "Usage:\n  seseragi --version\n  seseragi --version-json\n  seseragi run path/to/app.ssrg\n  seseragi run path/to/package\n  seseragi build path/to/app.ssrg [--target process|web] [--out-dir path/to/dist]\n  seseragi build path/to/package [--target process|web] [--out-dir path/to/dist]\n  seseragi dev [path/to/package] [--host 127.0.0.1] [--port 3000] [--open]\n  seseragi format [--check] path/to/app.ssrg"
     );
 }

--- a/crates/seseragi-cli/tests/build.rs
+++ b/crates/seseragi-cli/tests/build.rs
@@ -617,4 +617,15 @@ fn reports_version_commit_and_channel() {
     assert!(stdout.contains("commit "));
     assert!(stdout.contains("target "));
     assert!(stdout.contains("development") || stdout.contains("release"));
+
+    let json = Command::new(env!("CARGO_BIN_EXE_seseragi"))
+        .arg("--version-json")
+        .output()
+        .unwrap();
+    assert_eq!(json.status.code(), Some(0));
+    let metadata: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(metadata["name"], "seseragi");
+    assert_eq!(metadata["version"], env!("CARGO_PKG_VERSION"));
+    assert!(metadata["commit"].is_string());
+    assert!(metadata["target"].is_string());
 }

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -965,6 +965,14 @@ reload clientを`index.html`へ注入するため、production `seseragi build`�
 dependencyは変更しません。SIGINTはwatch loopとlistenerを閉じ、`--host` / `--port` /
 `--open`はhost toolingだけが所有します。
 
+VS Code extensionのproject commandsはLSP custom methodを追加せず、
+`seseragi.cli.path`またはPATHで発見したnative CLIを直接spawnします。active
+`.ssrg`からowning workspace内の最も近いmanifestを選ぶため、CLI / LSPと別の
+project root推測を行いません。CLIは`--version-json`でshared release metadataを返し、
+extensionはversionとtargetがVSIXと一致することを命令前に検証します。Run /
+Buildは短命child、Devは一workspace一childとしてOutput Channel、status bar、
+browser URLを共有し、Stop / deactivateでSIGINT cleanupします。
+
 `schema-1/monad-laws`はFunctor identity / composition、Applicative identity / homomorphism、Monad left identity /
 right identity / associativityを一つの小さいuser-defined Maybe instance群で表現します。
 `execution-schema-1/monad-laws`は七つの比較結果をConsole traceとstdoutまで固定し、selected dictionary、supertrait

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -463,6 +463,12 @@ source / manifest変更後はfull reloadし、compile error中もserverと最後
 canonical `project-flow-app`の実process E2Eがinitial render artifact、rebuild、error recovery、port conflict、
 SIGINT cleanupを固定し、実browserでもrender、interaction、stateを初期化するreloadを確認しています。
 
+VS Code extensionから同じpackageをRun / Web Build / Dev / Stop / Open Browserで操作できます。
+extensionはCLIを直接spawnし、LSPはlanguage intelligenceだけを所有します。
+`seseragi --version-json`のidentity / version / target handshake、nearest manifest root、Output Channel、
+dev status / URL、duplicate prevention、deactivate cleanupをextension integration testで固定し、
+native release archive smokeもCLIのmachine-readable metadataを実行検証します。
+
 Playground-1は`apps/playground`へCodeMirror 6、専用Seseragi highlight、mobile panel、任意Stdin、
 driver diagnosticsのsource range表示を実装しました。Vercel buildはreview済みWASM artifactを静的bundleするため
 Rust installを要求しません。Rust移行完了後に旧React / Monaco Playgroundは削除し、

--- a/extensions/seseragi/CHANGELOG.md
+++ b/extensions/seseragi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.4.7
+
+- Adds project Run, Web Build, Development Server, Stop, and Open Browser
+  commands backed directly by the version-checked Seseragi CLI.
+- Shows project output, dev lifecycle state, and the reported browser URL, and
+  cleans up the owned development process when the extension deactivates.
+
 ## 0.4.0
 
 - Uses the shared Seseragi toolchain version and the unified `v<version>`

--- a/extensions/seseragi/README.md
+++ b/extensions/seseragi/README.md
@@ -11,6 +11,7 @@ untitled documentへ次を提供します。
 - 現行Rust compilerと同じAnalysis APIを使うnative language server
 - hover、completion、signature help、definition、diagnostic、quick fix
 - CLIと同じformatterを使うFormat Document
+- CLIを直接使うproject Run / Web Build / Dev / Stop / Open Browser
 - semantic tokensによる型・symbol情報を使ったhighlightの補完
 
 TextMate grammarはserver起動前も使える字句highlightを担当し、semantic tokensは
@@ -51,6 +52,27 @@ resolverで追跡します。`seseragi.toml`があるfolderではそのmanifest�
 package importを使い、保存前のopen bufferも解析に反映します。source fileまたは
 `seseragi.toml`の作成・削除・rename時には、影響するmodule graphのdiagnosticを更新します。
 workspace外とuntitled documentはsingle-file解析へ安全にfallbackします。
+
+## Project commands
+
+manifest-backed package内の`.ssrg`を開くと、Command Paletteから次を実行できます。
+
+- `Seseragi: Run Project`
+- `Seseragi: Build Web App`
+- `Seseragi: Start Development Server`
+- `Seseragi: Stop Development Server`
+- `Seseragi: Open in Browser`
+
+extensionはLSPにprocess管理を追加せず、native releaseの`seseragi` CLIを直接
+spawnします。通常はPATH上から検出し、custom installだけ
+`seseragi.cli.path`を設定します。実行前に`--version-json`でextensionとCLIの
+version / platformを確認します。
+
+active fileからworkspace内の最も近い`seseragi.toml`をproject rootとし、stdout /
+stderrは`Seseragi Projects` Output Channelへ送ります。Dev status barはstarting /
+rebuilding / running / failed / stoppedとbrowser URLを表示し、二重起動を拒否します。
+workspace closeやextension deactivate時はchild processを停止します。VSIXはLSPのみを
+同梱し、CLIはCLI / LSPの両方を含むnative release archiveからinstallします。
 
 ## Formatting
 

--- a/extensions/seseragi/extension-core.js
+++ b/extensions/seseragi/extension-core.js
@@ -2,6 +2,7 @@ const fs = require("node:fs")
 const path = require("node:path")
 const { execFile } = require("node:child_process")
 const { version: EXPECTED_TOOLCHAIN_VERSION } = require("./package.json")
+const { createProjectCommandController } = require("./project-commands")
 
 const EXTENSION_ID = "seseragi-dev.seseragi"
 const LEGACY_EXTENSION_ID = "seseragi-dev.seseragi-spec-preview"
@@ -230,6 +231,12 @@ function createExtensionController({
   platform = process.platform,
   arch = process.arch,
 }) {
+  const projectCommands = createProjectCommandController({
+    vscode,
+    expectedTarget: serverTargetTriple(platform, arch),
+    existsSync,
+    platform,
+  })
   let client
   let output
   let status
@@ -389,6 +396,7 @@ function createExtensionController({
     status.command = "seseragi.showLanguageServerOutput"
     status.show()
     context.subscriptions.push(output, status)
+    await projectCommands.activate(context)
     context.subscriptions.push(
       vscode.commands.registerCommand("seseragi.showLanguageServerOutput", () =>
         output.show(true)
@@ -435,6 +443,7 @@ function createExtensionController({
   }
 
   async function deactivate() {
+    await projectCommands.deactivate()
     await stopClient()
   }
 

--- a/extensions/seseragi/package.json
+++ b/extensions/seseragi/package.json
@@ -33,7 +33,13 @@
     "onLanguage:seseragi",
     "onCommand:seseragi.migrateLegacySettings",
     "onCommand:seseragi.restartLanguageServer",
-    "onCommand:seseragi.showLanguageServerOutput"
+    "onCommand:seseragi.showLanguageServerOutput",
+    "onCommand:seseragi.runProject",
+    "onCommand:seseragi.buildWebApp",
+    "onCommand:seseragi.startDevelopmentServer",
+    "onCommand:seseragi.stopDevelopmentServer",
+    "onCommand:seseragi.openInBrowser",
+    "onCommand:seseragi.showProjectOutput"
   ],
   "scripts": {
     "build": "esbuild extension.js --bundle --minify --platform=node --external:vscode --outfile=dist/extension.js",
@@ -77,8 +83,48 @@
         "command": "seseragi.migrateLegacySettings",
         "title": "Migrate Legacy Settings",
         "category": "Seseragi"
+      },
+      {
+        "command": "seseragi.runProject",
+        "title": "Run Project",
+        "category": "Seseragi",
+        "icon": "$(play)"
+      },
+      {
+        "command": "seseragi.buildWebApp",
+        "title": "Build Web App",
+        "category": "Seseragi"
+      },
+      {
+        "command": "seseragi.startDevelopmentServer",
+        "title": "Start Development Server",
+        "category": "Seseragi"
+      },
+      {
+        "command": "seseragi.stopDevelopmentServer",
+        "title": "Stop Development Server",
+        "category": "Seseragi"
+      },
+      {
+        "command": "seseragi.openInBrowser",
+        "title": "Open in Browser",
+        "category": "Seseragi"
+      },
+      {
+        "command": "seseragi.showProjectOutput",
+        "title": "Show Project Output",
+        "category": "Seseragi"
       }
     ],
+    "menus": {
+      "editor/title/run": [
+        {
+          "command": "seseragi.runProject",
+          "when": "resourceLangId == seseragi",
+          "group": "navigation"
+        }
+      ]
+    },
     "configuration": {
       "title": "Seseragi",
       "properties": {
@@ -86,6 +132,11 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Optional path to a custom `seseragi-lsp` executable. Leave empty to use the platform binary bundled with the extension."
+        },
+        "seseragi.cli.path": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional path to the `seseragi` CLI. Leave empty to discover `seseragi` on PATH. The extension validates the CLI version before running project commands."
         }
       }
     },

--- a/extensions/seseragi/project-commands.js
+++ b/extensions/seseragi/project-commands.js
@@ -1,0 +1,423 @@
+const fs = require("node:fs")
+const path = require("node:path")
+const { execFile, spawn } = require("node:child_process")
+const { version: EXPECTED_TOOLCHAIN_VERSION } = require("./package.json")
+
+const DEV_URL_PATTERN = /^Dev server: (https?:\/\/\S+)$/m
+
+function readCliVersion(command, run = execFile) {
+  return new Promise((resolve, reject) => {
+    run(
+      command,
+      ["--version-json"],
+      { encoding: "utf8", timeout: 5000, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(
+            new Error(
+              `Could not run ${command} --version-json: ${stderr || error.message}`
+            )
+          )
+          return
+        }
+        try {
+          resolve(JSON.parse(stdout))
+        } catch (parseError) {
+          reject(
+            new Error(
+              `Seseragi CLI returned invalid version metadata: ${parseError.message}`
+            )
+          )
+        }
+      }
+    )
+  })
+}
+
+function validateCliVersion(version, expectedTarget) {
+  if (version?.name !== "seseragi") {
+    throw new Error("The selected executable is not the Seseragi CLI.")
+  }
+  if (version.version !== EXPECTED_TOOLCHAIN_VERSION) {
+    throw new Error(
+      "Seseragi extension/CLI version mismatch: " +
+        `expected ${EXPECTED_TOOLCHAIN_VERSION}; received ` +
+        `${version.version ?? "unknown"}. Install the matching Seseragi CLI ` +
+        "or set seseragi.cli.path."
+    )
+  }
+  if (expectedTarget !== undefined && version.target !== expectedTarget) {
+    throw new Error(
+      "Seseragi extension/CLI target mismatch: " +
+        `expected ${expectedTarget}; received ${version.target ?? "unknown"}. ` +
+        "Install the CLI for this platform or set seseragi.cli.path."
+    )
+  }
+  return version
+}
+
+function isInside(candidate, root) {
+  const relative = path.relative(root, candidate)
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+function resolveProjectRoot({
+  resourcePath,
+  workspaceFolders = [],
+  existsSync = fs.existsSync,
+}) {
+  const roots = workspaceFolders.map((folder) => path.resolve(folder.uri.fsPath))
+  if (resourcePath) {
+    const resource = path.resolve(resourcePath)
+    const workspace = roots
+      .filter((root) => isInside(resource, root))
+      .sort((left, right) => right.length - left.length)[0]
+    if (!workspace) {
+      throw new Error("The selected Seseragi file is outside the open workspace.")
+    }
+    let current = path.extname(resource) ? path.dirname(resource) : resource
+    while (isInside(current, workspace)) {
+      if (existsSync(path.join(current, "seseragi.toml"))) return current
+      if (current === workspace) break
+      current = path.dirname(current)
+    }
+    throw new Error(
+      `No seseragi.toml was found between ${resource} and workspace ${workspace}.`
+    )
+  }
+
+  const candidates = roots.filter((root) =>
+    existsSync(path.join(root, "seseragi.toml"))
+  )
+  if (candidates.length === 1) return candidates[0]
+  if (candidates.length === 0) {
+    throw new Error(
+      "Open a Seseragi package or focus a .ssrg file inside a package first."
+    )
+  }
+  throw new Error("Focus a .ssrg file to choose one Seseragi package.")
+}
+
+function createProjectCommandController({
+  vscode,
+  processSpawner = spawn,
+  versionReader = readCliVersion,
+  expectedTarget,
+  existsSync = fs.existsSync,
+  platform = process.platform,
+}) {
+  let output
+  let status
+  let context
+  let devProcess
+  let devRoot
+  let devUrl
+  let runSequence = Promise.resolve()
+
+  const log = (message) => output?.appendLine(`[Seseragi Project] ${message}`)
+
+  function updateStatus(state, detail) {
+    if (!status) return
+    const states = {
+      idle: ["$(circle-outline) Seseragi Dev", "stopped"],
+      starting: ["$(sync~spin) Seseragi Dev", "starting"],
+      running: ["$(broadcast) Seseragi Dev", "running"],
+      rebuilding: ["$(sync~spin) Seseragi Dev", "rebuilding"],
+      failed: ["$(error) Seseragi Dev", "failed"],
+    }
+    const [text, label] = states[state]
+    status.text = text
+    status.tooltip = `Seseragi Development Server: ${label}${
+      detail ? `; ${detail}` : ""
+    }`
+    status.command =
+      state === "running" ? "seseragi.openInBrowser" : "seseragi.showProjectOutput"
+  }
+
+  function configuredCli() {
+    const override = vscode.workspace
+      .getConfiguration("seseragi")
+      .get("cli.path", "")
+      .trim()
+    return override
+      ? { command: override, source: "seseragi.cli.path" }
+      : { command: platform === "win32" ? "seseragi.exe" : "seseragi", source: "PATH" }
+  }
+
+  async function checkedCli() {
+    const cli = configuredCli()
+    const version = validateCliVersion(
+      await versionReader(cli.command),
+      expectedTarget
+    )
+    log(
+      `CLI: ${cli.command} (${cli.source}); version ${version.version}; ` +
+        `target ${version.target ?? "unknown"}`
+    )
+    return cli.command
+  }
+
+  function selectedResource(resource) {
+    if (resource?.fsPath) return resource.fsPath
+    const editor = vscode.window.activeTextEditor
+    return editor?.document?.uri?.scheme === "file"
+      ? editor.document.uri.fsPath
+      : undefined
+  }
+
+  function projectRoot(resource) {
+    return resolveProjectRoot({
+      resourcePath: selectedResource(resource),
+      workspaceFolders: vscode.workspace.workspaceFolders || [],
+      existsSync,
+    })
+  }
+
+  function appendChunk(stream, prefix, onText) {
+    if (!stream?.on) return
+    stream.on("data", (chunk) => {
+      const text = String(chunk)
+      output?.append(text)
+      onText?.(text)
+      if (prefix && !text.endsWith("\n")) output?.append("\n")
+    })
+  }
+
+  function spawnCli(command, arguments_, root) {
+    log(`command: ${command} ${arguments_.join(" ")}`)
+    log(`project: ${root}`)
+    return processSpawner(command, arguments_, {
+      cwd: root,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+  }
+
+  async function runOnce(kind, arguments_, resource) {
+    const root = projectRoot(resource)
+    const command = await checkedCli()
+    const child = spawnCli(command, arguments_(root), root)
+    appendChunk(child.stdout)
+    appendChunk(child.stderr)
+    output.show(true)
+    await new Promise((resolve, reject) => {
+      child.once("error", reject)
+      child.once("close", (code, signal) => {
+        if (code === 0) {
+          log(`${kind} completed`)
+          resolve()
+        } else {
+          reject(
+            new Error(
+              `${kind} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`
+            )
+          )
+        }
+      })
+    })
+  }
+
+  async function reportFailure(error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log(`ERROR ${message}`)
+    updateStatus("failed", message)
+    const action = await vscode.window.showErrorMessage(
+      `Seseragi project command failed. ${message}`,
+      "Show Output",
+      "Open Settings"
+    )
+    if (action === "Show Output") output.show(true)
+    if (action === "Open Settings") {
+      await vscode.commands.executeCommand(
+        "workbench.action.openSettings",
+        "seseragi.cli.path"
+      )
+    }
+  }
+
+  function queue(action) {
+    runSequence = runSequence.then(action, action).catch(reportFailure)
+    return runSequence
+  }
+
+  async function startDev(resource) {
+    if (devProcess) {
+      await vscode.window.showInformationMessage(
+        `Seseragi development server is already running for ${devRoot}.`
+      )
+      return
+    }
+    const root = projectRoot(resource)
+    const command = await checkedCli()
+    updateStatus("starting", path.basename(root))
+    devRoot = root
+    devUrl = undefined
+    const child = spawnCli(command, ["dev", root], root)
+    devProcess = child
+    let stdout = ""
+    appendChunk(child.stdout, undefined, (text) => {
+      stdout = `${stdout}${text}`.slice(-8192)
+      const match = stdout.match(DEV_URL_PATTERN)
+      if (match) {
+        devUrl = match[1]
+        updateStatus("running", `${path.basename(root)} at ${devUrl}`)
+        log(`browser: ${devUrl}`)
+      } else if (text.includes("Built web app") && devUrl) {
+        updateStatus("running", `${path.basename(root)} at ${devUrl}`)
+      }
+    })
+    appendChunk(child.stderr, undefined, (text) => {
+      if (text.includes("Build failed") || text.includes("error[")) {
+        updateStatus("failed", `compiler diagnostics in ${path.basename(root)}`)
+      }
+    })
+    child.once("error", (error) => {
+      if (devProcess === child) {
+        devProcess = undefined
+        devRoot = undefined
+        devUrl = undefined
+      }
+      void reportFailure(error)
+    })
+    child.once("close", (code, signal) => {
+      if (devProcess !== child) return
+      devProcess = undefined
+      const stoppedRoot = devRoot
+      devRoot = undefined
+      devUrl = undefined
+      if (code === 0 || signal) {
+        updateStatus("idle", stoppedRoot ? path.basename(stoppedRoot) : undefined)
+        log("development server stopped")
+      } else {
+        void reportFailure(
+          new Error(`development server exited with code ${code}`)
+        )
+      }
+    })
+    output.show(true)
+  }
+
+  async function stopDev() {
+    const child = devProcess
+    if (!child) {
+      updateStatus("idle")
+      await vscode.window.showInformationMessage(
+        "No Seseragi development server is running."
+      )
+      return
+    }
+    log("stopping development server")
+    child.kill(platform === "win32" ? undefined : "SIGINT")
+  }
+
+  async function openInBrowser() {
+    if (!devUrl) {
+      await vscode.window.showErrorMessage(
+        "The Seseragi development server has not reported a browser URL yet."
+      )
+      return
+    }
+    await vscode.env.openExternal(vscode.Uri.parse(devUrl))
+  }
+
+  async function activate(activationContext) {
+    context = activationContext
+    output = vscode.window.createOutputChannel("Seseragi Projects")
+    status = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      99
+    )
+    updateStatus("idle")
+    status.show()
+    context.subscriptions.push(output, status)
+    for (const pattern of ["**/*.ssrg", "**/seseragi.toml"]) {
+      const watcher = vscode.workspace.createFileSystemWatcher(pattern)
+      watcher.onDidChange?.((uri) => {
+        if (devProcess && devRoot && isInside(uri.fsPath, devRoot)) {
+          updateStatus("rebuilding", path.basename(devRoot))
+        }
+      })
+      watcher.onDidCreate?.((uri) => {
+        if (devProcess && devRoot && isInside(uri.fsPath, devRoot)) {
+          updateStatus("rebuilding", path.basename(devRoot))
+        }
+      })
+      watcher.onDidDelete?.((uri) => {
+        if (devProcess && devRoot && isInside(uri.fsPath, devRoot)) {
+          updateStatus("rebuilding", path.basename(devRoot))
+        }
+      })
+      context.subscriptions.push(watcher)
+    }
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeWorkspaceFolders?.(() => {
+        if (
+          devProcess &&
+          devRoot &&
+          !(vscode.workspace.workspaceFolders || []).some((folder) =>
+            isInside(devRoot, folder.uri.fsPath)
+          )
+        ) {
+          log("owning workspace closed; stopping development server")
+          devProcess.kill(platform === "win32" ? undefined : "SIGINT")
+        }
+      }) || { dispose() {} }
+    )
+    context.subscriptions.push(
+      vscode.commands.registerCommand("seseragi.showProjectOutput", () =>
+        output.show(true)
+      ),
+      vscode.commands.registerCommand("seseragi.runProject", (resource) =>
+        queue(() => runOnce("run", (root) => ["run", root], resource))
+      ),
+      vscode.commands.registerCommand("seseragi.buildWebApp", (resource) =>
+        queue(() =>
+          runOnce(
+            "Web build",
+            (root) => ["build", root, "--target", "web", "--out-dir", "dist"],
+            resource
+          )
+        )
+      ),
+      vscode.commands.registerCommand(
+        "seseragi.startDevelopmentServer",
+        (resource) => queue(() => startDev(resource))
+      ),
+      vscode.commands.registerCommand("seseragi.stopDevelopmentServer", () =>
+        stopDev()
+      ),
+      vscode.commands.registerCommand("seseragi.openInBrowser", () =>
+        openInBrowser()
+      )
+    )
+  }
+
+  async function deactivate() {
+    if (devProcess) {
+      const child = devProcess
+      child.kill(platform === "win32" ? undefined : "SIGINT")
+      await new Promise((resolve) => {
+        const timeout = setTimeout(resolve, 2000)
+        child.once("close", () => {
+          clearTimeout(timeout)
+          resolve()
+        })
+      })
+      if (devProcess === child) {
+        child.kill()
+        devProcess = undefined
+      }
+    }
+  }
+
+  return { activate, deactivate }
+}
+
+module.exports = {
+  DEV_URL_PATTERN,
+  EXPECTED_TOOLCHAIN_VERSION,
+  createProjectCommandController,
+  readCliVersion,
+  resolveProjectRoot,
+  validateCliVersion,
+}

--- a/extensions/seseragi/scripts/verify-package.ts
+++ b/extensions/seseragi/scripts/verify-package.ts
@@ -320,10 +320,21 @@ export async function verifyPackage(
   for (const command of [
     "seseragi.restartLanguageServer",
     "seseragi.showLanguageServerOutput",
+    "seseragi.runProject",
+    "seseragi.buildWebApp",
+    "seseragi.startDevelopmentServer",
+    "seseragi.stopDevelopmentServer",
+    "seseragi.openInBrowser",
   ]) {
     if (!commands.has(command)) {
       throw new Error(`VSIX is missing command ${command}`)
     }
+  }
+  if (
+    manifest.contributes?.configuration?.properties?.["seseragi.cli.path"]
+      ?.default !== ""
+  ) {
+    throw new Error("VSIX does not expose optional Seseragi CLI discovery")
   }
 
   await smokeExtractedPackage({

--- a/extensions/seseragi/tests/project-commands.test.ts
+++ b/extensions/seseragi/tests/project-commands.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from "bun:test"
+import { EventEmitter } from "node:events"
+import path from "node:path"
+import manifest from "../package.json"
+
+const {
+  createProjectCommandController,
+  resolveProjectRoot,
+  validateCliVersion,
+} = require("../project-commands")
+
+class MockStream extends EventEmitter {
+  write(text: string) {
+    this.emit("data", Buffer.from(text))
+  }
+}
+
+class MockChild extends EventEmitter {
+  stdout = new MockStream()
+  stderr = new MockStream()
+  killedWith: string | undefined
+
+  kill(signal?: string) {
+    this.killedWith = signal
+    queueMicrotask(() => this.emit("close", 0, signal ?? null))
+    return true
+  }
+}
+
+function projectHarness() {
+  const commands = new Map<string, (...args: unknown[]) => unknown>()
+  const children: MockChild[] = []
+  const spawns: Array<{
+    command: string
+    arguments: string[]
+    options: { cwd: string }
+  }> = []
+  const lines: string[] = []
+  const opened: string[] = []
+  const information: string[] = []
+  const errors: string[] = []
+  const watchers: Array<{
+    pattern: string
+    change?: (uri: { fsPath: string }) => void
+  }> = []
+  let workspaceChange: (() => void) | undefined
+  const status = { text: "", tooltip: "", command: "", show() {} }
+  const output = {
+    append(value: string) {
+      lines.push(value)
+    },
+    appendLine(value: string) {
+      lines.push(`${value}\n`)
+    },
+    show() {},
+    dispose() {},
+  }
+  const project = "/workspace/apps/site"
+  const source = path.join(project, "src/main.ssrg")
+  const vscode = {
+    StatusBarAlignment: { Left: 1 },
+    Uri: {
+      parse(value: string) {
+        return { value }
+      },
+    },
+    env: {
+      async openExternal(uri: { value: string }) {
+        opened.push(uri.value)
+        return true
+      },
+    },
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: "/workspace" } }],
+      getConfiguration() {
+        return {
+          get(_key: string, fallback: string) {
+            return "/tools/seseragi" || fallback
+          },
+        }
+      },
+      createFileSystemWatcher(pattern: string) {
+        const watcher: {
+          pattern: string
+          change?: (uri: { fsPath: string }) => void
+        } = { pattern }
+        watchers.push(watcher)
+        return {
+          onDidChange(callback: (uri: { fsPath: string }) => void) {
+            watcher.change = callback
+          },
+          onDidCreate() {},
+          onDidDelete() {},
+          dispose() {},
+        }
+      },
+      onDidChangeWorkspaceFolders(callback: () => void) {
+        workspaceChange = callback
+        return { dispose() {} }
+      },
+    },
+    window: {
+      activeTextEditor: {
+        document: { uri: { scheme: "file", fsPath: source } },
+      },
+      createOutputChannel() {
+        return output
+      },
+      createStatusBarItem() {
+        return status
+      },
+      async showInformationMessage(message: string) {
+        information.push(message)
+      },
+      async showErrorMessage(message: string) {
+        errors.push(message)
+      },
+    },
+    commands: {
+      registerCommand(
+        command: string,
+        callback: (...args: unknown[]) => unknown
+      ) {
+        commands.set(command, callback)
+        return { dispose() {} }
+      },
+      async executeCommand() {},
+    },
+  }
+  const controller = createProjectCommandController({
+    vscode,
+    processSpawner(
+      command: string,
+      arguments_: string[],
+      options: { cwd: string }
+    ) {
+      const child = new MockChild()
+      children.push(child)
+      spawns.push({ command, arguments: arguments_, options })
+      return child
+    },
+    versionReader: async () => ({
+      name: "seseragi",
+      version: manifest.version,
+      target: "aarch64-apple-darwin",
+    }),
+    expectedTarget: "aarch64-apple-darwin",
+    existsSync(candidate: string) {
+      return candidate === path.join(project, "seseragi.toml")
+    },
+    platform: "darwin",
+  })
+  const context = { subscriptions: [] as unknown[] }
+  return {
+    children,
+    commands,
+    context,
+    controller,
+    errors,
+    information,
+    lines,
+    opened,
+    output,
+    project,
+    source,
+    spawns,
+    status,
+    watchers,
+    workspaceClosed() {
+      vscode.workspace.workspaceFolders = []
+      workspaceChange?.()
+    },
+  }
+}
+
+async function waitFor(condition: () => boolean) {
+  for (let index = 0; index < 20; index += 1) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error("timed out waiting for test condition")
+}
+
+describe("VS Code project command integration", () => {
+  test("validates CLI identity, version, and target", () => {
+    const version = {
+      name: "seseragi",
+      version: manifest.version,
+      target: "aarch64-apple-darwin",
+    }
+    expect(validateCliVersion(version, "aarch64-apple-darwin")).toEqual(
+      version
+    )
+    expect(() =>
+      validateCliVersion({ ...version, name: "seseragi-lsp" })
+    ).toThrow("not the Seseragi CLI")
+    expect(() =>
+      validateCliVersion({ ...version, version: "0.3.0" })
+    ).toThrow("extension/CLI version mismatch")
+    expect(() =>
+      validateCliVersion(version, "x86_64-apple-darwin")
+    ).toThrow("extension/CLI target mismatch")
+  })
+
+  test("resolves the nearest manifest inside the owning workspace", () => {
+    expect(
+      resolveProjectRoot({
+        resourcePath: "/workspace/apps/site/src/main.ssrg",
+        workspaceFolders: [{ uri: { fsPath: "/workspace" } }],
+        existsSync(candidate: string) {
+          return candidate === "/workspace/apps/site/seseragi.toml"
+        },
+      })
+    ).toBe("/workspace/apps/site")
+    expect(() =>
+      resolveProjectRoot({
+        resourcePath: "/outside/main.ssrg",
+        workspaceFolders: [{ uri: { fsPath: "/workspace" } }],
+      })
+    ).toThrow("outside the open workspace")
+  })
+
+  test("registers commands and runs canonical CLI processes without terminals", async () => {
+    const harness = projectHarness()
+    await harness.controller.activate(harness.context)
+    expect([...harness.commands.keys()]).toEqual([
+      "seseragi.showProjectOutput",
+      "seseragi.runProject",
+      "seseragi.buildWebApp",
+      "seseragi.startDevelopmentServer",
+      "seseragi.stopDevelopmentServer",
+      "seseragi.openInBrowser",
+    ])
+
+    const run = harness.commands.get("seseragi.runProject")?.()
+    await waitFor(() => harness.spawns.length === 1)
+    expect(harness.spawns[0]).toEqual({
+      command: "/tools/seseragi",
+      arguments: ["run", harness.project],
+      options: expect.objectContaining({ cwd: harness.project }),
+    })
+    harness.children[0].stdout.write("program output\n")
+    harness.children[0].emit("close", 0, null)
+    await run
+
+    const build = harness.commands.get("seseragi.buildWebApp")?.()
+    await waitFor(() => harness.spawns.length === 2)
+    expect(harness.spawns[1].arguments).toEqual([
+      "build",
+      harness.project,
+      "--target",
+      "web",
+      "--out-dir",
+      "dist",
+    ])
+    harness.children[1].emit("close", 0, null)
+    await build
+    expect(harness.lines.join("")).toContain("program output")
+  })
+
+  test("owns one dev process, exposes its URL, rebuild state, and cleanup", async () => {
+    const harness = projectHarness()
+    await harness.controller.activate(harness.context)
+    await harness.commands.get("seseragi.startDevelopmentServer")?.()
+    const child = harness.children[0]
+    expect(harness.spawns[0].arguments).toEqual([
+      "dev",
+      harness.project,
+    ])
+    child.stdout.write("Built web app (100 ms; reload 1)\n")
+    child.stdout.write("Dev server: http://127.0.0.1:3000/\n")
+    expect(harness.status.text).toContain("Seseragi Dev")
+    expect(harness.status.tooltip).toContain("http://127.0.0.1:3000/")
+
+    harness.watchers[0].change?.({ fsPath: harness.source })
+    expect(harness.status.tooltip).toContain("rebuilding")
+    child.stdout.write("Built web app (90 ms; reload 2)\n")
+    expect(harness.status.tooltip).toContain("http://127.0.0.1:3000/")
+    child.stderr.write("error[SES-N0001]\nBuild failed\n")
+    expect(harness.status.tooltip).toContain("compiler diagnostics")
+    child.stdout.write("Built web app (80 ms; reload 3)\n")
+    expect(harness.status.tooltip).toContain("http://127.0.0.1:3000/")
+
+    await harness.commands.get("seseragi.openInBrowser")?.()
+    expect(harness.opened).toEqual(["http://127.0.0.1:3000/"])
+    await harness.commands.get("seseragi.startDevelopmentServer")?.()
+    expect(harness.children).toHaveLength(1)
+    expect(harness.information.join("\n")).toContain("already running")
+
+    harness.workspaceClosed()
+    expect(child.killedWith).toBe("SIGINT")
+    await harness.controller.deactivate()
+    expect(harness.children).toHaveLength(1)
+  })
+})

--- a/scripts/native-release.test.ts
+++ b/scripts/native-release.test.ts
@@ -59,7 +59,7 @@ test("packages, checksums, extracts and executes the host CLI and LSP", async ()
   try {
     await writeFile(
       cli,
-      `#!/bin/sh\nprintf '%s\\n' 'seseragi 0.4.0 (development, commit fixture, target ${rustTarget})'\n`
+      `#!/bin/sh\nif [ "$1" = "--version-json" ]; then\n  printf '%s\\n' '{"name":"seseragi","version":"0.4.0","target":"${rustTarget}","channel":"development","dirty":true,"releaseTag":null}'\nelse\n  printf '%s\\n' 'seseragi 0.4.0 (development, commit fixture, target ${rustTarget})'\nfi\n`
     )
     await writeFile(
       lsp,

--- a/scripts/native-release.ts
+++ b/scripts/native-release.ts
@@ -304,6 +304,26 @@ export async function verifyNativeRelease(
     if (options.release && !cliVersion.includes("(release,")) {
       fail(`seseragi is not a clean v${version} release build`)
     }
+    const cliMetadata = JSON.parse(
+      verifyExecutable(cli, ["--version-json"])
+    ) as Record<string, unknown>
+    if (
+      cliMetadata.name !== "seseragi" ||
+      cliMetadata.version !== version ||
+      cliMetadata.target !== contract.rustTarget
+    ) {
+      fail(
+        `seseragi --version-json does not match ${version}/${contract.rustTarget}`
+      )
+    }
+    if (
+      options.release &&
+      (cliMetadata.channel !== "release" ||
+        cliMetadata.dirty !== false ||
+        cliMetadata.releaseTag !== `v${version}`)
+    ) {
+      fail(`seseragi --version-json is not a clean v${version} release build`)
+    }
 
     const lspVersion = JSON.parse(
       verifyExecutable(lsp, ["--version-json"])


### PR DESCRIPTION
Closes #366\n\n## Summary\n- add direct VS Code Run, Web Build, Dev, Stop, Open Browser, and project output commands\n- validate the external CLI through a machine-readable release identity/version/target handshake\n- reuse the CLI project resolver while exposing output, lifecycle state, rebuilds, browser URL, duplicate prevention, and cleanup\n- verify the command surface in the packaged VSIX and execute CLI metadata from native release archives\n\n## Checks\n- cargo test -p seseragi-cli\n- bun run check:rust -- -p seseragi-cli\n- bun run check:extension\n- bun run check:release\n- bun test scripts/native-release.test.ts\n- bun run check