### PR TITLE
test: retain observed dev fallback response

### DIFF
--- a/crates/seseragi-cli/tests/dev.rs
+++ b/crates/seseragi-cli/tests/dev.rs
@@ -376,12 +376,22 @@ fn recovers_when_the_initial_build_has_compiler_diagnostics() {
         .spawn()
         .unwrap();
 
+    let mut initial_fallback = None;
     wait_for(
         Duration::from_secs(10),
-        || request(port, "/").is_some_and(|response| response.0 == 503),
+        || {
+            request(port, "/").is_some_and(|(status, body)| {
+                if status == 503 {
+                    initial_fallback = Some(body);
+                    true
+                } else {
+                    false
+                }
+            })
+        },
         "initial diagnostic fallback",
     );
-    let (_, fallback) = request(port, "/").unwrap();
+    let fallback = initial_fallback.unwrap();
     assert!(fallback.contains("Build failed"));
     assert!(fallback.contains("/__seseragi_dev/version"));
     assert!(child.try_wait().unwrap().is_none());


### PR DESCRIPTION
## Summary

- remove a TOCTOU race from the CLI dev recovery test
- retain and assert the 503 response that satisfied readiness instead of opening an immediate second connection

## Validation

- `cargo fmt --check`
- focused recovery test passed 10 consecutive runs
- `bun scripts/release-readiness.ts check-pr origin/main HEAD` (surfaces: none)

Unblocks the guarded v0.5.0 release for #385.