### PR TITLE
release: install Chromium before source gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
           bun scripts/release-contract.ts check
           bun scripts/release-contract.ts check-tag "$RELEASE_TAG"
           bun scripts/release-readiness.ts check
+      - name: Install Chromium for browser lifecycle tests
+        run: |
+          cd apps/playground
+          bun install --frozen-lockfile
+          bunx playwright install chromium
       - name: Run repository-wide release source gate
         run: ./scripts/check-scoped.sh release-gate-after-wasm
       - name: Create the canonical tag after the source gate

--- a/scripts/release-gate.test.ts
+++ b/scripts/release-gate.test.ts
@@ -78,6 +78,10 @@ describe("release publish gate", () => {
     expect(workflow).toContain(
       "run: ./scripts/check-scoped.sh release-gate-after-wasm"
     )
+    expect(workflow).toContain("bunx playwright install chromium")
+    expect(workflow.indexOf("bunx playwright install chromium")).toBeLessThan(
+      workflow.indexOf("release-gate-after-wasm")
+    )
     expect(workflow).toContain("branches: [main]")
     expect(workflow).toContain("workflow_dispatch:")
     expect(workflow).toContain("cancel-in-progress: false")


### PR DESCRIPTION
Follow-up to #413 and #340.

The v0.12.0 release source gate runs the real-browser DOM lifecycle test, but its macOS runner did not install Playwright Chromium. Install the lockfile-pinned Playground dependencies and Chromium before the repository-wide gate.

Validation:
- bun test scripts/release-gate.test.ts
- biome check scripts/release-gate.test.ts
- git diff --check