### PR TITLE
Release: normalize Postgres bundle paths

### DIFF
--- a/runtime/providers/postgres/pg.bundle.js
+++ b/runtime/providers/postgres/pg.bundle.js
@@ -18,7 +18,7 @@ var __toESM = (mod, isNodeMode, target) => {
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 var __require = import.meta.require;
 
-// ../seseragi/node_modules/postgres-array/index.js
+// node_modules/postgres-array/index.js
 var require_postgres_array = __commonJS((exports) => {
   exports.parse = function(source, transform) {
     return new ArrayParser(source, transform).parse();
@@ -114,7 +114,7 @@ var require_postgres_array = __commonJS((exports) => {
   }
 });
 
-// ../seseragi/node_modules/pg-types/lib/arrayParser.js
+// node_modules/pg-types/lib/arrayParser.js
 var require_arrayParser = __commonJS((exports, module) => {
   var array = require_postgres_array();
   module.exports = {
@@ -128,7 +128,7 @@ var require_arrayParser = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/postgres-date/index.js
+// node_modules/postgres-date/index.js
 var require_postgres_date = __commonJS((exports, module) => {
   var DATE_TIME = /(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?.*?( BC)?$/;
   var DATE = /^(\d{1,})-(\d{2})-(\d{2})( BC)?$/;
@@ -213,7 +213,7 @@ var require_postgres_date = __commonJS((exports, module) => {
   }
 });
 
-// ../seseragi/node_modules/xtend/mutable.js
+// node_modules/xtend/mutable.js
 var require_mutable = __commonJS((exports, module) => {
   module.exports = extend;
   var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -230,7 +230,7 @@ var require_mutable = __commonJS((exports, module) => {
   }
 });
 
-// ../seseragi/node_modules/postgres-interval/index.js
+// node_modules/postgres-interval/index.js
 var require_postgres_interval = __commonJS((exports, module) => {
   var extend = require_mutable();
   module.exports = PostgresInterval;
@@ -322,7 +322,7 @@ var require_postgres_interval = __commonJS((exports, module) => {
   }
 });
 
-// ../seseragi/node_modules/postgres-bytea/index.js
+// node_modules/postgres-bytea/index.js
 var require_postgres_bytea = __commonJS((exports, module) => {
   var bufferFrom = Buffer.from || Buffer;
   module.exports = function parseBytea(input) {
@@ -355,7 +355,7 @@ var require_postgres_bytea = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg-types/lib/textParsers.js
+// node_modules/pg-types/lib/textParsers.js
 var require_textParsers = __commonJS((exports, module) => {
   var array = require_postgres_array();
   var arrayParser = require_arrayParser();
@@ -558,7 +558,7 @@ var require_textParsers = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg-int8/index.js
+// node_modules/pg-int8/index.js
 var require_pg_int8 = __commonJS((exports, module) => {
   var BASE = 1e6;
   function readInt8(buffer) {
@@ -635,7 +635,7 @@ var require_pg_int8 = __commonJS((exports, module) => {
   module.exports = readInt8;
 });
 
-// ../seseragi/node_modules/pg-types/lib/binaryParsers.js
+// node_modules/pg-types/lib/binaryParsers.js
 var require_binaryParsers = __commonJS((exports, module) => {
   var parseInt64 = require_pg_int8();
   var parseBits = function(data, bits, offset, invert, callback) {
@@ -834,7 +834,7 @@ var require_binaryParsers = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg-types/lib/builtins.js
+// node_modules/pg-types/lib/builtins.js
 var require_builtins = __commonJS((exports, module) => {
   module.exports = {
     BOOL: 16,
@@ -900,7 +900,7 @@ var require_builtins = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg-types/index.js
+// node_modules/pg-types/index.js
 var require_pg_types = __commonJS((exports) => {
   var textParsers = require_textParsers();
   var binaryParsers = require_binaryParsers();
@@ -939,7 +939,7 @@ var require_pg_types = __commonJS((exports) => {
   });
 });
 
-// ../seseragi/node_modules/pg/lib/defaults.js
+// node_modules/pg/lib/defaults.js
 var require_defaults = __commonJS((exports, module) => {
   var user;
   try {
@@ -980,7 +980,7 @@ var require_defaults = __commonJS((exports, module) => {
   });
 });
 
-// ../seseragi/node_modules/pg/lib/utils.js
+// node_modules/pg/lib/utils.js
 var require_utils = __commonJS((exports, module) => {
   var defaults = require_defaults();
   var { isDate } = __require("util/types");
@@ -1129,7 +1129,7 @@ var require_utils = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg/lib/crypto/utils.js
+// node_modules/pg/lib/crypto/utils.js
 var require_utils2 = __commonJS((exports, module) => {
   var nodeCrypto = __require("crypto");
   module.exports = {
@@ -1178,7 +1178,7 @@ var require_utils2 = __commonJS((exports, module) => {
   }
 });
 
-// ../seseragi/node_modules/pg/lib/crypto/cert-signatures.js
+// node_modules/pg/lib/crypto/cert-signatures.js
 var require_cert_signatures = __commonJS((exports, module) => {
   function x509Error(msg, cert) {
     return new Error("SASL channel binding: " + msg + " when parsing public certificate " + cert.toString("base64"));
@@ -1290,7 +1290,7 @@ var require_cert_signatures = __commonJS((exports, module) => {
   module.exports = { signatureAlgorithmHashFromCertificate };
 });
 
-// ../seseragi/node_modules/pg/lib/crypto/sasl.js
+// node_modules/pg/lib/crypto/sasl.js
 var require_sasl = __commonJS((exports, module) => {
   var crypto = require_utils2();
   var { signatureAlgorithmHashFromCertificate } = require_cert_signatures();
@@ -1470,7 +1470,7 @@ var require_sasl = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg/lib/type-overrides.js
+// node_modules/pg/lib/type-overrides.js
 var require_type_overrides = __commonJS((exports, module) => {
   var types = require_pg_types();
   function TypeOverrides(userTypes) {
@@ -1502,7 +1502,7 @@ var require_type_overrides = __commonJS((exports, module) => {
   module.exports = TypeOverrides;
 });
 
-// ../seseragi/node_modules/pg-connection-string/index.js
+// node_modules/pg-connection-string/index.js
 var require_pg_connection_string = __commonJS((exports, module) => {
   function parse(str, options = {}) {
     if (str.charAt(0) === "/") {
@@ -1683,7 +1683,7 @@ See https://www.postgresql.org/docs/current/libpq-ssl.html for libpq SSL mode de
   parse.parseIntoClientConfig = parseIntoClientConfig;
 });
 
-// ../seseragi/node_modules/pg/lib/connection-parameters.js
+// node_modules/pg/lib/connection-parameters.js
 var require_connection_parameters = __commonJS((exports, module) => {
   var dns = __require("dns");
   var defaults = require_defaults();
@@ -1830,7 +1830,7 @@ var require_connection_parameters = __commonJS((exports, module) => {
   module.exports = ConnectionParameters;
 });
 
-// ../seseragi/node_modules/pg/lib/result.js
+// node_modules/pg/lib/result.js
 var require_result = __commonJS((exports, module) => {
   var types = require_pg_types();
   var matchRegexp = /^([A-Za-z]+)(?: (\d+))?(?: (\d+))?/;
@@ -1918,7 +1918,7 @@ var require_result = __commonJS((exports, module) => {
   module.exports = Result;
 });
 
-// ../seseragi/node_modules/pg/lib/query.js
+// node_modules/pg/lib/query.js
 var require_query = __commonJS((exports, module) => {
   var { EventEmitter } = __require("events");
   var Result = require_result();
@@ -2109,7 +2109,7 @@ var require_query = __commonJS((exports, module) => {
   module.exports = Query;
 });
 
-// ../seseragi/node_modules/pg-protocol/dist/messages.js
+// node_modules/pg-protocol/dist/messages.js
 var require_messages = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.NoticeMessage = exports.DataRowMessage = exports.CommandCompleteMessage = exports.ReadyForQueryMessage = exports.NotificationResponseMessage = exports.BackendKeyDataMessage = exports.AuthenticationMD5Password = exports.ParameterStatusMessage = exports.ParameterDescriptionMessage = exports.RowDescriptionMessage = exports.Field = exports.CopyResponse = exports.CopyDataMessage = exports.DatabaseError = exports.copyDone = exports.emptyQuery = exports.replicationStart = exports.portalSuspended = exports.noData = exports.closeComplete = exports.bindComplete = exports.parseComplete = undefined;
@@ -2285,7 +2285,7 @@ var require_messages = __commonJS((exports) => {
   exports.NoticeMessage = NoticeMessage;
 });
 
-// ../seseragi/node_modules/pg-protocol/dist/buffer-writer.js
+// node_modules/pg-protocol/dist/buffer-writer.js
 var require_buffer_writer = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.Writer = undefined;
@@ -2381,7 +2381,7 @@ var require_buffer_writer = __commonJS((exports) => {
   exports.Writer = Writer;
 });
 
-// ../seseragi/node_modules/pg-protocol/dist/serializer.js
+// node_modules/pg-protocol/dist/serializer.js
 var require_serializer = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.serialize = undefined;
@@ -2549,7 +2549,7 @@ var require_serializer = __commonJS((exports) => {
   exports.serialize = serialize;
 });
 
-// ../seseragi/node_modules/pg-protocol/dist/buffer-reader.js
+// node_modules/pg-protocol/dist/buffer-reader.js
 var require_buffer_reader = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.BufferReader = undefined;
@@ -2605,7 +2605,7 @@ var require_buffer_reader = __commonJS((exports) => {
   exports.BufferReader = BufferReader;
 });
 
-// ../seseragi/node_modules/pg-protocol/dist/parser.js
+// node_modules/pg-protocol/dist/parser.js
 var require_parser = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.Parser = undefined;
@@ -2910,7 +2910,7 @@ var require_parser = __commonJS((exports) => {
   };
 });
 
-// ../seseragi/node_modules/pg-protocol/dist/index.js
+// node_modules/pg-protocol/dist/index.js
 var require_dist = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.DatabaseError = exports.serialize = undefined;
@@ -2931,13 +2931,13 @@ var require_dist = __commonJS((exports) => {
   }
 });
 
-// ../seseragi/node_modules/pg-cloudflare/dist/empty.js
+// node_modules/pg-cloudflare/dist/empty.js
 var require_empty = __commonJS((exports) => {
   Object.defineProperty(exports, "__esModule", { value: true });
   exports.default = {};
 });
 
-// ../seseragi/node_modules/pg/lib/stream.js
+// node_modules/pg/lib/stream.js
 var require_stream = __commonJS((exports, module) => {
   var { getStream, getSecureStream } = getStreamFuncs();
   module.exports = {
@@ -2992,7 +2992,7 @@ var require_stream = __commonJS((exports, module) => {
   }
 });
 
-// ../seseragi/node_modules/pg/lib/connection.js
+// node_modules/pg/lib/connection.js
 var require_connection = __commonJS((exports, module) => {
   var EventEmitter = __require("events").EventEmitter;
   var { parse, serialize } = require_dist();
@@ -3185,7 +3185,7 @@ var require_connection = __commonJS((exports, module) => {
   module.exports = Connection;
 });
 
-// ../seseragi/node_modules/split2/index.js
+// node_modules/split2/index.js
 var require_split2 = __commonJS((exports, module) => {
   var { Transform } = __require("stream");
   var { StringDecoder } = __require("string_decoder");
@@ -3284,7 +3284,7 @@ var require_split2 = __commonJS((exports, module) => {
   module.exports = split;
 });
 
-// ../seseragi/node_modules/pgpass/lib/helper.js
+// node_modules/pgpass/lib/helper.js
 var require_helper = __commonJS((exports, module) => {
   var path = __require("path");
   var Stream = __require("stream").Stream;
@@ -3448,7 +3448,7 @@ var require_helper = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pgpass/lib/index.js
+// node_modules/pgpass/lib/index.js
 var require_lib = __commonJS((exports, module) => {
   var path = __require("path");
   var fs = __require("fs");
@@ -3466,7 +3466,7 @@ var require_lib = __commonJS((exports, module) => {
   module.exports.warnTo = helper.warnTo;
 });
 
-// ../seseragi/node_modules/pg/lib/client.js
+// node_modules/pg/lib/client.js
 var require_client = __commonJS((exports, module) => {
   var EventEmitter = __require("events").EventEmitter;
   var utils = require_utils();
@@ -4112,7 +4112,7 @@ var require_client = __commonJS((exports, module) => {
   module.exports = Client;
 });
 
-// ../seseragi/node_modules/pg-pool/index.js
+// node_modules/pg-pool/index.js
 var require_pg_pool = __commonJS((exports, module) => {
   var EventEmitter = __require("events").EventEmitter;
   var NOOP = function() {};
@@ -4524,7 +4524,7 @@ var require_pg_pool = __commonJS((exports, module) => {
   module.exports = Pool;
 });
 
-// ../seseragi/node_modules/pg/lib/native/query.js
+// node_modules/pg/lib/native/query.js
 var require_query2 = __commonJS((exports, module) => {
   var EventEmitter = __require("events").EventEmitter;
   var util = __require("util");
@@ -4660,7 +4660,7 @@ var require_query2 = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg/lib/native/client.js
+// node_modules/pg/lib/native/client.js
 var require_client2 = __commonJS((exports, module) => {
   var nodeUtils = __require("util");
   var Native;
@@ -4986,7 +4986,7 @@ var require_client2 = __commonJS((exports, module) => {
   };
 });
 
-// ../seseragi/node_modules/pg/lib/index.js
+// node_modules/pg/lib/index.js
 var require_lib2 = __commonJS((exports, module) => {
   var Client = require_client();
   var defaults = require_defaults();
@@ -5048,7 +5048,7 @@ var require_lib2 = __commonJS((exports, module) => {
   });
 });
 
-// ../seseragi/node_modules/pg-cursor/index.js
+// node_modules/pg-cursor/index.js
 var require_pg_cursor = __commonJS((exports, module) => {
   var Result2 = require_result();
   var prepare = require_utils().prepareValue;
@@ -5241,7 +5241,7 @@ var require_pg_cursor = __commonJS((exports, module) => {
   module.exports = Cursor;
 });
 
-// ../seseragi/node_modules/pg/esm/index.mjs
+// node_modules/pg/esm/index.mjs
 var import_lib = __toESM(require_lib2(), 1);
 var Client = import_lib.default.Client;
 var Pool = import_lib.default.Pool;
@@ -5256,7 +5256,7 @@ var TypeOverrides = import_lib.default.TypeOverrides;
 var defaults = import_lib.default.defaults;
 var esm_default = import_lib.default;
 
-// ../seseragi/node_modules/pg-cursor/esm/index.mjs
+// node_modules/pg-cursor/esm/index.mjs
 var import___ = __toESM(require_pg_cursor(), 1);
 var esm_default2 = import___.default;
 

--- a/scripts/postgres-provider-bundle.ts
+++ b/scripts/postgres-provider-bundle.ts
@@ -17,8 +17,17 @@ if (!result.success || result.outputs.length !== 1) {
   throw new Error("failed to bundle the PostgreSQL Provider")
 }
 
-const generated = await result.outputs[0]?.text()
-if (generated === undefined) throw new Error("PostgreSQL bundle is missing")
+const rawGenerated = await result.outputs[0]?.text()
+if (rawGenerated === undefined) throw new Error("PostgreSQL bundle is missing")
+
+// Bun includes resolved dependency paths in generated section comments. A
+// linked node_modules directory in a dedicated worktree makes those comments
+// point outside the checkout even though the executable output is identical.
+// Keep the committed bundle reproducible across regular and linked installs.
+const generated = rawGenerated.replace(
+  /^\/\/ (?:\.\.\/[^/\n]+\/)+node_modules\//gm,
+  "// node_modules/"
+)
 
 if (process.argv.includes("--write")) {
   await Bun.write(outputPath, generated)


### PR DESCRIPTION
Fix the v0.19.0 release gate blocked after #422.

- normalize Bun section comments when node_modules is linked outside a dedicated worktree
- regenerate the committed PostgreSQL Provider bundle with checkout-relative paths
- verify freshness against both linked-worktree and regular frozen installs

Validation:
- bun run postgres:bundle:check
- bun x biome check scripts/postgres-provider-bundle.ts
- git diff --check